### PR TITLE
DO NOT MERGE — temporary SEC noise filter (fix extractor upstream instead)

### DIFF
--- a/backend/db/seed_supplier_subsidary.py
+++ b/backend/db/seed_supplier_subsidary.py
@@ -1,12 +1,80 @@
 import json
 import re
 import psycopg2
+from collections import Counter
 from pathlib import Path
 import sys
 import os
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from config import DATABASE_URL
+
+# ── SEC Exhibit 21.1 noise filter ───────────────────────────────────────
+#
+# The subsidiaries extractor pulls BOTH columns of the Exhibit 21.1 table
+# (entity name + jurisdiction of incorporation), so country names,
+# US state names, and the literal table header "Entity Name" show up as
+# fake subsidiary entries under almost every parent. The resolver then
+# substring-matches these single-word strings to real tickers and
+# produces garbage edges like "Cadence Design Systems → National Bank
+# of Greece".
+#
+# Two-layer defense: a hard-coded denylist for the obvious offenders,
+# plus a frequency cap (a target legitimately owned by >N distinct
+# parents is almost certainly boilerplate, not a real relationship).
+_NOISE_DENYLIST_LOWER = {
+    # Placeholder / header noise
+    "none", "", "entity name", "jurisdiction", "jurisdiction of incorporation",
+    "name of subsidiary", "subsidiary", "significant subsidiaries",
+    "n/a", "not applicable",
+
+    # Countries (Exhibit 21.1 jurisdiction column)
+    "united states", "united kingdom", "united arab emirates",
+    "argentina", "australia", "austria", "belgium", "brazil",
+    "bulgaria", "canada", "chile", "china", "colombia", "costa rica",
+    "croatia", "czech republic", "denmark", "egypt", "estonia",
+    "finland", "france", "germany", "greece", "hong kong", "hungary",
+    "iceland", "india", "indonesia", "ireland", "israel", "italy",
+    "japan", "jordan", "kenya", "korea", "south korea", "north korea",
+    "latvia", "lebanon", "lithuania", "luxembourg", "malaysia",
+    "malta", "mexico", "morocco", "netherlands", "new zealand",
+    "nigeria", "norway", "oman", "pakistan", "panama", "peru",
+    "philippines", "poland", "portugal", "puerto rico", "qatar",
+    "romania", "russia", "saudi arabia", "singapore", "slovakia",
+    "slovenia", "south africa", "spain", "sri lanka", "sweden",
+    "switzerland", "taiwan", "thailand", "turkey", "ukraine",
+    "uruguay", "venezuela", "vietnam",
+
+    # Continents / regions
+    "europe", "asia", "africa", "north america", "south america",
+    "latin america", "middle east", "caribbean",
+
+    # Common offshore / incorporation jurisdictions
+    "bermuda", "cayman islands", "british virgin islands",
+    "channel islands", "isle of man", "jersey", "guernsey",
+
+    # US states + DC (common as the jurisdiction column for US subs)
+    "alabama", "alaska", "arizona", "arkansas", "california",
+    "colorado", "connecticut", "delaware", "florida", "georgia",
+    "hawaii", "idaho", "illinois", "indiana", "iowa", "kansas",
+    "kentucky", "louisiana", "maine", "maryland", "massachusetts",
+    "michigan", "minnesota", "mississippi", "missouri", "montana",
+    "nebraska", "nevada", "new hampshire", "new jersey", "new mexico",
+    "new york", "north carolina", "north dakota", "ohio", "oklahoma",
+    "oregon", "pennsylvania", "rhode island", "south carolina",
+    "south dakota", "tennessee", "texas", "utah", "vermont",
+    "virginia", "washington", "west virginia", "wisconsin", "wyoming",
+    "district of columbia",
+
+    # Misc truncation artifacts we saw in the data
+    "argenti",
+}
+
+# A target name that appears under more than this many distinct parent
+# companies is treated as boilerplate noise and dropped even if it
+# isn't in the denylist above. Tune if you see real relationships
+# getting filtered out.
+MAX_PARENTS_PER_TARGET = 5
 
 # Corporate suffixes to strip during normalization (order matters — longer
 # multi-word forms before single-word ones to avoid partial stripping).
@@ -151,9 +219,10 @@ def seed_relationships():
     inserted_subsidiaries = 0
     skipped_unresolved = 0
     skipped_missing_source = 0
+    skipped_noise = 0
 
     def process_file(filepath, relation_key, rel_type):
-        nonlocal inserted_suppliers, inserted_subsidiaries, skipped_unresolved, skipped_missing_source
+        nonlocal inserted_suppliers, inserted_subsidiaries, skipped_unresolved, skipped_missing_source, skipped_noise
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 data = json.load(f)
@@ -168,6 +237,41 @@ def seed_relationships():
         else:
             records = data
 
+        # Pre-pass: count how many DISTINCT parents list each target. A
+        # target appearing under >MAX_PARENTS_PER_TARGET distinct parents
+        # is treated as boilerplate noise regardless of what it is.
+        target_parent_count: dict[str, set] = {}
+        for record in records:
+            src = record.get("ticker")
+            if not src:
+                continue
+            for t in record.get(relation_key, []):
+                if not t:
+                    continue
+                target_parent_count.setdefault(t, set()).add(src)
+
+        noisy_by_frequency = {
+            t for t, parents in target_parent_count.items()
+            if len(parents) > MAX_PARENTS_PER_TARGET
+        }
+        if noisy_by_frequency:
+            # Only log the top 10 offenders so we can see what we're dropping
+            top = sorted(noisy_by_frequency,
+                         key=lambda t: -len(target_parent_count[t]))[:10]
+            print(f"  [{rel_type}] frequency filter: dropping {len(noisy_by_frequency)} "
+                  f"targets that appear under >{MAX_PARENTS_PER_TARGET} distinct parents")
+            for t in top:
+                print(f"    {len(target_parent_count[t]):5d}× {t!r}")
+
+        def is_noise(target: str) -> bool:
+            if not target:
+                return True
+            if target.strip().lower() in _NOISE_DENYLIST_LOWER:
+                return True
+            if target in noisy_by_frequency:
+                return True
+            return False
+
         for record in records:
             source_ticker = record.get("ticker")
             if not source_ticker:
@@ -180,14 +284,12 @@ def seed_relationships():
 
             targets = record.get(relation_key, [])
             for target in targets:
-                if target == "NONE":
+                if is_noise(target):
+                    skipped_noise += 1
                     continue
-                
+
                 actual_target = resolve_target(target)
                 if not actual_target:
-                    # Most subsidiary entries are legal entity names, not
-                    # tickers — printing every unresolved target swamps
-                    # stdout. Just count them and summarize at the end.
                     skipped_unresolved += 1
                     continue
 
@@ -199,7 +301,7 @@ def seed_relationships():
                     VALUES (%s, %s, %s)
                     ON CONFLICT (source_ticker, target_ticker, relationship_type) DO NOTHING
                 """, (actual_source, actual_target, rel_type))
-                
+
                 if cursor.rowcount > 0:
                     if rel_type == "supplier":
                         inserted_suppliers += 1
@@ -227,6 +329,7 @@ def seed_relationships():
     print(f"  Resolved by substring match:     {_counts[3]}")
     print(f"  Skipped unresolved:              {skipped_unresolved}")
     print(f"  Skipped missing source ticker:   {skipped_missing_source}")
+    print(f"  Skipped SEC noise (jurisdictions/boilerplate): {skipped_noise}")
     print("=" * 54)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status: safety net, not the real fix

Filed as a **draft** so GitHub shows it won't merge without explicit undraft.
The real fix lives in \`sec_pipeline/subsidiaries/extractor.py\`, not here.

## Why this is a bandaid

The extractor defaults to Ollama with \`llama3.2\` (3B parameters). The
prompt correctly tells the model not to include jurisdictions of
incorporation, but llama3.2 is too small to reliably obey negative
instructions on multi-column input. So country names like 'Poland',
'Malaysia', 'Delaware', US states, and the literal table header
'Entity Name' all leak into \`subsidiaries.json\`.

Evidence from a frequency audit of the current \`subsidiaries.json\`:

\`\`\`
Top offenders (same target under N distinct parents):
  2077× 'NONE'
   335× 'Poland'
   291× 'Malaysia'
   244× 'Austria'
   ...                   (countries, states, and headers all the way down)
\`\`\`

A real subsidiary name appearing under >5 distinct parents is almost
certainly boilerplate noise.

## What this PR does

Before \`resolve_target()\` runs, drop:
1. Anything in a hard denylist (countries, US states, 'NONE', 'Entity Name').
2. Any target appearing under >5 distinct parents (catches future noise
   forms the denylist misses).

## Why it shouldn't ship

Filtering downstream rots as the extractor emits new failure modes. We
should instead:

1. Switch the extractor's default from \`llama3.2\` → \`gpt-4o-mini\` (~\$3
   one-time run) or Claude Haiku 4.5 (~\$20 one-time run). Both follow
   negative instructions reliably.
2. Validate extractor output against known-good ground truth (AAPL,
   NVDA, JPM, WMT — tickers with published subsidiary lists on SEC
   EDGAR).
3. Or: replace Exhibit 21.1 extraction entirely with Wikidata SPARQL
   (free, structured, returns only public↔public pairs by construction).
4. Regenerate \`subsidiaries.json\` with the fixed pipeline and upload to S3.
5. Close this PR.

## Until then

If at any point you need something to protect the live graph from the
current bad data, this branch can be merged as a *temporary* measure.
Delete once upstream is fixed.

## Related

- Issue filing for AI team to fix the extractor: TBD
- Original bad-edge spot check: \`Cadence Design Systems → National Bank
  of Greece\`, \`Pebblebrook Hotel Trust → Orange S.A.\`, etc.