### PR TITLE
feat(ci): GitHub Actions deploy to EC2 on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to production
+
+# Triggers:
+#  - push to main (auto-deploy after PR merge)
+#  - manual run from the Actions tab (workflow_dispatch) for re-deploys without a code change
+on:
+  push:
+    branches: [main]
+    # Only build when something that actually runs in prod changes.
+    # Docs-only / ai-pipeline-only commits don't need a prod restart.
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'scraper/**'
+      - 'wsgi.py'
+      - 'deploy/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false  # never cut a deploy mid-flight
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Repo-settings → Environments → create "production" with required
+    # reviewers if you want a human approval step per deploy. Without
+    # that, this is fire-on-merge.
+    environment: production
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host:     ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key:      ${{ secrets.EC2_SSH_KEY }}
+          port:     22
+          # Bash strict mode: any failed command aborts the deploy.
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /home/ubuntu/nexus
+
+            echo "─── Pull latest main ───"
+            git fetch --prune origin
+            git reset --hard origin/main
+            echo "Now at: $(git log -1 --oneline)"
+
+            echo "─── Refresh Python deps (no-op if unchanged) ───"
+            source .venv/bin/activate
+            pip install -q -r backend/requirements.txt
+            pip install -q -r scraper/requirements.txt
+
+            echo "─── Restart gunicorn ───"
+            sudo /bin/systemctl restart nexus
+            sleep 3
+            sudo /bin/systemctl is-active nexus
+
+            echo "─── Smoke test ───"
+            # /config is the one endpoint that doesn't require Firebase auth,
+            # so it's our reliable heartbeat. 200 = service healthy.
+            curl --fail --silent --show-error --max-time 5 \
+                 http://127.0.0.1:5001/nexus/api/config > /dev/null
+            echo "Deploy OK"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -115,6 +115,13 @@ still present) and the sidebar populated from the real DB.
 
 ## Updating after new commits land
 
+**Automated (GitHub Actions, default):** every push to `main` triggers
+[.github/workflows/deploy.yml](../.github/workflows/deploy.yml) which SSHes
+into the box, pulls, installs any new deps, restarts `nexus.service`, and
+smoke-tests `/config`. See "CI/CD deploy" below for one-time setup.
+
+**Manual fallback:**
+
 ```bash
 cd /home/ubuntu/nexus
 git pull origin main
@@ -124,6 +131,75 @@ sudo systemctl restart nexus                  # ~1s downtime
 ```
 
 For schema changes, run `python backend/db/init.py` first (it's idempotent).
+
+---
+
+## CI/CD deploy (one-time setup)
+
+The workflow SSHes into the EC2 box on every `main` push and runs:
+`git reset --hard origin/main` → pip install → `systemctl restart nexus`
+→ curl `/config` as a smoke test. Three things to wire up once.
+
+### 1. SSH key for the Action to authenticate with
+
+Generate a deploy-only key pair (not tied to any person's identity):
+
+```bash
+# On your laptop
+ssh-keygen -t ed25519 -f ~/.ssh/nexus-deploy -N "" -C "github-actions@nexus"
+
+# Put the PUBLIC key on the box's authorized_keys
+cat ~/.ssh/nexus-deploy.pub
+# copy that line, ssh into the box, append to ~/.ssh/authorized_keys
+
+# The PRIVATE key contents go into GitHub Secrets (step 3 below)
+cat ~/.ssh/nexus-deploy
+```
+
+### 2. Passwordless sudo for the `restart` command
+
+The workflow can't type a sudo password. Grant just enough sudo to
+restart nexus (nothing else):
+
+```bash
+# On the box
+sudo cp /home/ubuntu/nexus/deploy/sudoers-nexus-deploy /etc/sudoers.d/nexus-deploy
+sudo chmod 440 /etc/sudoers.d/nexus-deploy
+sudo visudo -c         # must print "parsed OK"
+
+# Verify
+sudo -n /bin/systemctl is-active nexus    # prints "active" with no prompt
+```
+
+### 3. GitHub repository secrets
+
+Repo → **Settings** → **Secrets and variables** → **Actions** →
+**New repository secret**. Add three:
+
+| Name | Value |
+|---|---|
+| `EC2_HOST` | `54.70.37.194` (or the public DNS name) |
+| `EC2_USER` | `ubuntu` |
+| `EC2_SSH_KEY` | full contents of `~/.ssh/nexus-deploy` (the PRIVATE key, PEM) |
+
+### 4. (Recommended) Require human approval per deploy
+
+Repo → **Settings** → **Environments** → **New environment** → name
+`production` → check **Required reviewers** → add yourself. Every deploy
+then waits for 👍 in the Actions tab before SSHing.
+
+### 5. (Recommended) Branch protection on `main`
+
+Repo → **Settings** → **Branches** → Add rule → pattern `main` →
+require PR reviews before merging. With the `production` environment
+gate above, that gives you "only deploy reviewed code" without the
+review itself being the deploy trigger.
+
+### Triggering a deploy manually
+
+Actions tab → **Deploy to production** → **Run workflow** → pick `main`.
+Useful when you change an env var in `.env` and want the service to
+pick it up without touching git.
 
 ---
 

--- a/deploy/sudoers-nexus-deploy
+++ b/deploy/sudoers-nexus-deploy
@@ -1,0 +1,12 @@
+# /etc/sudoers.d/nexus-deploy
+#
+# Lets the `ubuntu` user restart only the nexus.service without a password,
+# which is what the GitHub Actions deploy workflow needs. No other sudo
+# rights are granted.
+#
+# Install:
+#   sudo cp deploy/sudoers-nexus-deploy /etc/sudoers.d/nexus-deploy
+#   sudo chmod 440 /etc/sudoers.d/nexus-deploy
+#   sudo visudo -c            # validates syntax; must say "parsed OK"
+
+ubuntu ALL=(root) NOPASSWD: /bin/systemctl restart nexus, /bin/systemctl is-active nexus, /bin/systemctl status nexus


### PR DESCRIPTION
## Summary

Automates what used to be a manual ssh + git pull + systemctl restart cycle. Every push to main triggers a deploy; `production` environment gate (if configured in repo settings) keeps a human approval in the loop.

## What changes

- **`.github/workflows/deploy.yml`** — SSHes via appleboy/ssh-action, runs \`git reset --hard origin/main\`, \`pip install -q\`, \`systemctl restart nexus\`, curls \`/nexus/api/config\` as smoke test. Path-filtered so docs-only commits don't bounce the service.
- **`deploy/sudoers-nexus-deploy`** — grants \`ubuntu\` NOPASSWD for only \`systemctl restart/is-active/status nexus\`. Nothing else.
- **`deploy/README.md`** — CI/CD setup section (keygen, pubkey, sudoers, GitHub secrets, optional environment + branch-protection gates).

## Required secrets (set in repo Settings after merge)

| Name | Value |
|---|---|
| \`EC2_HOST\` | \`54.70.37.194\` |
| \`EC2_USER\` | \`ubuntu\` |
| \`EC2_SSH_KEY\` | dedicated ed25519 private key |

## Test plan

- [ ] Merge triggers a workflow run (files under \`deploy/\` changed)
- [ ] Workflow connects, pulls, restarts nexus, smoke-tests \`/config\` → 200
- [ ] iPick app at \`/\` still returns 200 after the restart (unaffected)
- [ ] Manual re-dispatch via "Run workflow" button also works