### PR TITLE
feat(fetchers): Wikidata + DBpedia + OpenCorporates subsidiary data sources

### DIFF
--- a/fetchers/README.md
+++ b/fetchers/README.md
@@ -3,7 +3,14 @@
 Alternative data sources for the `relationships` table, complementing (or
 replacing) the SEC Exhibit 21.1 extractor in `sec_pipeline/`.
 
-Both scripts write their output to JSON matching the schema
+| Source | Output | Key req? | Notes |
+|---|---|---|---|
+| `wikidata_subsidiaries.py`    | ~580 edges  | No  | Primary. SPARQL on P355 + P414 ticker qualifiers. |
+| `dbpedia_subsidiaries.py`     | ~12 edges   | No  | Supplemental. Catches recent US acquisitions Wikidata missed. |
+| `opencorporates_relationships.py` | varies   | Yes | Dormant unless you have an OC API key. |
+| `merge_subsidiaries.py`       | —           | —   | Unions the above into one file + writes a per-edge provenance sidecar. |
+
+All scripts write their output to JSON matching the schema
 `seed_supplier_subsidary.py` already understands:
 
 ```json
@@ -80,21 +87,75 @@ output), three options:
 
 Option 1 is cleanest; a follow-up PR can wire it in.
 
+## `dbpedia_subsidiaries.py`
+
+One SPARQL query to dbpedia.org. Reads `dbo:subsidiary` statements and
+cross-references with `dbo:symbol` / `dbp:symbol` for tickers on both
+sides. Covers a different slice than Wikidata — notably recent US
+acquisitions (e.g. CVS → Oak Street Health, INTC → MBLY, HPE → JNPR)
+that Wikidata hasn't ingested yet.
+
+Output is small (~10–20 edges after cleanup) because DBpedia's symbol
+fields are sparsely populated. Don't use as a standalone source — it's
+only worth running as a supplement to Wikidata.
+
+No API key required.
+
+```bash
+python fetchers/dbpedia_subsidiaries.py
+```
+
+## `merge_subsidiaries.py`
+
+Takes multiple fetcher outputs and produces one combined file in the
+same seeder schema, plus a `*.provenance.json` sidecar recording which
+source(s) contributed each edge. Edges that appear in multiple sources
+are strong candidates for high-confidence weighting.
+
+```bash
+python fetchers/merge_subsidiaries.py \
+    out/wikidata_subsidiaries.json:wikidata \
+    out/dbpedia_subsidiaries.json:dbpedia \
+    --out out/merged_subsidiaries.json
+```
+
+The per-positional syntax is `PATH:SOURCE_LABEL`. Example output:
+
+```
+Merged: 367 parents, 589 unique edges → out/merged_subsidiaries.json
+
+Edge provenance breakdown:
+    577 edges from wikidata
+      9 edges from dbpedia
+      3 edges from dbpedia + wikidata   ← cross-validated, highest confidence
+```
+
 ## Running order
 
 Typical refresh:
 
 ```bash
-# 1. Wikidata — always free, always first
-python fetchers/wikidata_subsidiaries.py --upload-s3
+# 1. Wikidata — primary, free, always first
+python fetchers/wikidata_subsidiaries.py
 
-# 2. OpenCorporates — expensive, use the Wikidata output as its ticker
-#    universe so we have names for the OC name-search step
+# 2. DBpedia — supplemental, free
+python fetchers/dbpedia_subsidiaries.py
+
+# 3. (Optional) OpenCorporates — only if you have a paid key
 export OPENCORPORATES_API_KEY=oc_xxxxxxxx
 python fetchers/opencorporates_relationships.py \
-    --tickers-json out/wikidata_subsidiaries.json \
-    --upload-s3
+    --tickers-json out/wikidata_subsidiaries.json
 
-# 3. Re-seed the DB on the EC2 box
+# 4. Merge into a single file
+python fetchers/merge_subsidiaries.py \
+    out/wikidata_subsidiaries.json:wikidata \
+    out/dbpedia_subsidiaries.json:dbpedia \
+    --out out/merged_subsidiaries.json
+
+# 5. Upload the merged file to S3 under the key the seeder expects
+aws s3 cp out/merged_subsidiaries.json \
+    s3://ipickai-storage/metadata/subsidiaries.json
+
+# 6. Re-seed the DB on the EC2 box
 python backend/db/seed_supplier_subsidary.py
 ```

--- a/fetchers/README.md
+++ b/fetchers/README.md
@@ -1,0 +1,100 @@
+# Relationship fetchers
+
+Alternative data sources for the `relationships` table, complementing (or
+replacing) the SEC Exhibit 21.1 extractor in `sec_pipeline/`.
+
+Both scripts write their output to JSON matching the schema
+`seed_supplier_subsidary.py` already understands:
+
+```json
+[
+  {"ticker": "PARENT", "subsidiaries": ["CHILD1", "CHILD2", ...]}
+]
+```
+
+Values in the `subsidiaries` array are **tickers**, not names, so the
+seeder's exact-ticker match path handles them with zero fuzzy resolution
+— none of the noise problems we saw with the SEC extractor.
+
+## `wikidata_subsidiaries.py`
+
+One SPARQL query to query.wikidata.org. Returns every (parent, subsidiary)
+pair where both sides are publicly-traded (both have a ticker in
+Wikidata's P249 property). Takes ~30 seconds end-to-end and is free.
+
+```bash
+python fetchers/wikidata_subsidiaries.py
+python fetchers/wikidata_subsidiaries.py --out out/wikidata_subsidiaries.json --upload-s3
+```
+
+Output covers well-known public parents (Alphabet, Berkshire, J&J, etc.)
+but has thin coverage for smaller / foreign issuers. Good precision,
+moderate recall.
+
+No API key required.
+
+## `opencorporates_relationships.py`
+
+Hits the OpenCorporates v0.4 API for every ticker: searches by company
+name, grabs the top match, reads its `controlling_entity` to infer a
+parent. Broader coverage than Wikidata (especially for mid-caps and
+foreign subs), but rate-limited:
+
+| Plan | Calls/month | ~ tickers/run (2 calls each) |
+|---|---|---|
+| Free | 500 | 250 |
+| Public Data ($59/mo) | 5,000 | 2,500 |
+| Premium | 10,000+ | 5,000+ |
+
+The script is **resumable** — checkpoints the output after every 25 tickers,
+so a 429 or Ctrl+C doesn't lose progress. Re-run to continue.
+
+```bash
+export OPENCORPORATES_API_KEY=oc_xxxxxxxx
+
+# Seed the ticker list from the Wikidata output (which already has names)
+python fetchers/opencorporates_relationships.py \
+    --tickers-json out/wikidata_subsidiaries.json \
+    --limit 200 \
+    --out out/opencorporates_subsidiaries.json
+
+# Or from a plain ticker list
+python fetchers/opencorporates_relationships.py \
+    --tickers-file scraper/basket_tickers.txt \
+    --out out/opencorporates_subsidiaries.json
+```
+
+Add `--upload-s3` to push the final JSON up to `ipickai-storage/metadata/`.
+
+## Integrating with the seeder
+
+Once you have `out/wikidata_subsidiaries.json` (and optionally the OC
+output), three options:
+
+1. **Upload to S3, update `S3_URIS` in `seed_supplier_subsidary.py`** to
+   pull these keys instead of / in addition to the SEC `subsidiaries.json`.
+2. **Merge the two JSONs manually** into a combined `subsidiaries.json`
+   and upload to S3 under the existing key.
+3. **Keep as a parallel data source** and have the seeder union all
+   three files in memory before inserting.
+
+Option 1 is cleanest; a follow-up PR can wire it in.
+
+## Running order
+
+Typical refresh:
+
+```bash
+# 1. Wikidata — always free, always first
+python fetchers/wikidata_subsidiaries.py --upload-s3
+
+# 2. OpenCorporates — expensive, use the Wikidata output as its ticker
+#    universe so we have names for the OC name-search step
+export OPENCORPORATES_API_KEY=oc_xxxxxxxx
+python fetchers/opencorporates_relationships.py \
+    --tickers-json out/wikidata_subsidiaries.json \
+    --upload-s3
+
+# 3. Re-seed the DB on the EC2 box
+python backend/db/seed_supplier_subsidary.py
+```

--- a/fetchers/dbpedia_subsidiaries.py
+++ b/fetchers/dbpedia_subsidiaries.py
@@ -1,0 +1,130 @@
+"""
+Fetch public-to-public subsidiary relationships from DBpedia.
+
+Complements fetchers/wikidata_subsidiaries.py. DBpedia is Wikipedia's
+structured-data mirror — different coverage profile than Wikidata, and
+in particular tends to have more recent US acquisitions that Wikidata
+hasn't picked up yet (e.g. CVS→OSH, INTC→MBLY, HPE→JNPR).
+
+Volume is small (~10–20 edges after cleanup) because DBpedia's
+`dbo:symbol` / `dbp:symbol` property is sparsely populated. Use as a
+merge input to the Wikidata output, not a standalone source.
+
+Output schema matches the seeder:
+    [{"ticker": "PARENT", "name": "...", "subsidiaries": ["CHILD1", ...]}]
+
+Usage:
+    python fetchers/dbpedia_subsidiaries.py
+    python fetchers/dbpedia_subsidiaries.py --out out/dbpedia_subsidiaries.json --upload-s3
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+DBPEDIA_ENDPOINT = "https://dbpedia.org/sparql"
+USER_AGENT = "nexus-ipick/0.1 (https://github.com/andrewyzhou/nexus) requests/python"
+
+# DBpedia uses dbo:subsidiary (parent → sub, forward). Tickers live under
+# either dbo:symbol (the curated ontology property) or dbp:symbol (the
+# raw-infobox property) depending on how the Wikipedia page was written,
+# so we UNION both sides for recall.
+SPARQL_QUERY = """
+SELECT DISTINCT ?parentLabel ?parentTicker ?subLabel ?subTicker WHERE {
+  ?parent dbo:subsidiary ?sub .
+  { ?parent dbo:symbol ?parentTicker } UNION { ?parent dbp:symbol ?parentTicker }
+  { ?sub    dbo:symbol ?subTicker    } UNION { ?sub    dbp:symbol ?subTicker }
+  ?parent rdfs:label ?parentLabel . FILTER(LANG(?parentLabel) = "en")
+  ?sub    rdfs:label ?subLabel    . FILTER(LANG(?subLabel)   = "en")
+  FILTER(?parent != ?sub)
+}
+"""
+
+
+def run_query() -> list[dict]:
+    r = requests.get(
+        DBPEDIA_ENDPOINT,
+        params={"query": SPARQL_QUERY, "format": "application/sparql-results+json"},
+        headers={"User-Agent": USER_AGENT},
+        timeout=90,
+    )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+def to_subsidiaries_json(bindings: list[dict]) -> list[dict]:
+    by_parent: dict[str, set[str]] = defaultdict(set)
+    name_of: dict[str, str] = {}
+
+    for row in bindings:
+        p_tkr = row["parentTicker"]["value"].upper().strip()
+        s_tkr = row["subTicker"]["value"].upper().strip()
+
+        # DBpedia tickers sometimes include exchange prefixes ("NASDAQ: GOOGL")
+        # or punctuation. Keep the last colon-separated segment and trim.
+        p_tkr = p_tkr.split(":")[-1].strip()
+        s_tkr = s_tkr.split(":")[-1].strip()
+
+        if not p_tkr or not s_tkr or p_tkr == s_tkr:
+            continue
+        if p_tkr.isdigit() or s_tkr.isdigit():
+            # Non-US exchanges we don't have in our companies table
+            continue
+
+        by_parent[p_tkr].add(s_tkr)
+        if p_tkr not in name_of:
+            name_of[p_tkr] = row["parentLabel"]["value"]
+
+    return [
+        {"ticker": parent, "name": name_of.get(parent), "subsidiaries": sorted(subs)}
+        for parent, subs in sorted(by_parent.items())
+    ]
+
+
+def maybe_upload_s3(path: Path) -> None:
+    import shutil
+    import subprocess
+    target = "s3://ipickai-storage/metadata/dbpedia_subsidiaries.json"
+    if shutil.which("aws"):
+        print(f"Uploading {path} → {target}")
+        subprocess.run(["aws", "s3", "cp", str(path), target], check=True)
+        return
+    try:
+        import boto3  # type: ignore
+        bucket, key = target.replace("s3://", "").split("/", 1)
+        boto3.client("s3").upload_file(str(path), bucket, key)
+        print(f"Uploaded via boto3: {target}")
+    except Exception as e:
+        print(f"!! S3 upload skipped ({e}). Manual: aws s3 cp {path} {target}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="out/dbpedia_subsidiaries.json")
+    parser.add_argument("--upload-s3", action="store_true")
+    args = parser.parse_args()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Querying DBpedia ({DBPEDIA_ENDPOINT})...")
+    bindings = run_query()
+    print(f"  got {len(bindings)} raw (parent, sub) ticker pairs")
+
+    records = to_subsidiaries_json(bindings)
+    total_subs = sum(len(r["subsidiaries"]) for r in records)
+    print(f"  collapsed into {len(records)} parents covering {total_subs} subsidiaries")
+
+    out_path.write_text(json.dumps(records, indent=2, ensure_ascii=False))
+    print(f"Wrote {out_path}")
+
+    if args.upload_s3:
+        maybe_upload_s3(out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/fetchers/merge_subsidiaries.py
+++ b/fetchers/merge_subsidiaries.py
@@ -1,0 +1,93 @@
+"""
+Merge multiple subsidiary JSON files into one, preserving per-edge provenance.
+
+Each input is expected in the seeder's shape:
+    [{"ticker": "PARENT", "subsidiaries": ["CHILD1", "CHILD2", ...]}]
+
+The merged output keeps the same shape (so the seeder doesn't need to
+change), but also writes a sidecar `*.provenance.json` that records
+which source(s) contributed each edge — useful for auditing and for
+weighting edges by confidence later.
+
+Usage:
+    python fetchers/merge_subsidiaries.py \\
+        out/wikidata_subsidiaries.json:wikidata \\
+        out/dbpedia_subsidiaries.json:dbpedia \\
+        --out out/merged_subsidiaries.json
+
+    # Each positional arg is PATH:SOURCE_LABEL
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("inputs", nargs="+",
+                        help="PATH:LABEL entries, e.g. out/wikidata.json:wikidata")
+    parser.add_argument("--out", default="out/merged_subsidiaries.json")
+    args = parser.parse_args()
+
+    # { parent_ticker: { child_ticker: set(source_labels) } }
+    edges: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    name_of: dict[str, str] = {}
+
+    for spec in args.inputs:
+        if ":" not in spec:
+            raise SystemExit(f"input spec {spec!r} missing :LABEL suffix")
+        path_str, label = spec.rsplit(":", 1)
+        path = Path(path_str)
+        if not path.exists():
+            print(f"  !! {path} does not exist — skipping")
+            continue
+        records = json.loads(path.read_text())
+        print(f"Loading {path} (label={label}): {len(records)} parents")
+        for rec in records:
+            parent = rec["ticker"]
+            if rec.get("name") and parent not in name_of:
+                name_of[parent] = rec["name"]
+            for child in rec.get("subsidiaries", []):
+                edges[parent][child].add(label)
+
+    # Write merged output in seeder shape
+    merged = [
+        {
+            "ticker": parent,
+            "name":   name_of.get(parent),
+            "subsidiaries": sorted(children.keys()),
+        }
+        for parent, children in sorted(edges.items())
+    ]
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False))
+    total_edges = sum(len(r["subsidiaries"]) for r in merged)
+    print(f"\nMerged: {len(merged)} parents, {total_edges} unique edges → {out_path}")
+
+    # Write provenance sidecar
+    prov_path = out_path.with_suffix(".provenance.json")
+    provenance = [
+        {
+            "parent": parent,
+            "child":  child,
+            "sources": sorted(sources),
+        }
+        for parent, children in sorted(edges.items())
+        for child, sources in sorted(children.items())
+    ]
+    prov_path.write_text(json.dumps(provenance, indent=2, ensure_ascii=False))
+
+    # Quick overlap summary so we can see how much each source contributes
+    from collections import Counter
+    combos = Counter(tuple(sorted(sources)) for p in edges.values() for sources in p.values())
+    print("\nEdge provenance breakdown:")
+    for combo, n in combos.most_common():
+        print(f"  {n:5d} edges from {' + '.join(combo)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fetchers/opencorporates_relationships.py
+++ b/fetchers/opencorporates_relationships.py
@@ -1,0 +1,290 @@
+"""
+Fetch parent-subsidiary relationships from OpenCorporates.
+
+Why: complements the Wikidata fetcher. OpenCorporates has broader
+coverage of private/mid-cap subs that Wikidata misses. Costs rate-limit
+budget though: ~2 API calls per ticker (search + detail), so 4,400
+tickers ≈ 9,000 calls. The free tier is 500 calls/month; the Public
+Data plan ($59/mo) is 5,000/mo. Plan your cap accordingly.
+
+What it does:
+  1. For each ticker in the input list, search OpenCorporates by name
+     (from a ticker → name map, usually from a prior yfinance seed).
+  2. Pick the best match (prefer the jurisdiction with the largest
+     number of matching identifier_uids, fall back to first result).
+  3. GET the company's full record, extract `controlling_entity` +
+     `ultimate_controlling_company`.
+  4. Record an inverted edge: if our ticker X has controlling_entity Y,
+     the graph edge is Y → X with relationship_type = "subsidiary"
+     (parent → child, matching the schema the seeder expects).
+
+Output schema matches seed_supplier_subsidary.py:
+
+    [
+      {"ticker": "PARENT_TKR", "subsidiaries": ["CHILD_TKR", ...]},
+      ...
+    ]
+
+The script is resumable — it writes its checkpoint after each batch and
+will skip tickers already present in the output file on the next run.
+
+Usage:
+    export OPENCORPORATES_API_KEY=oc_xxxxxxxx
+    python fetchers/opencorporates_relationships.py \\
+        --tickers-json out/wikidata_subsidiaries.json \\
+        --limit 200 \\
+        --out out/opencorporates_subsidiaries.json
+
+    # or feed it tickers from a plain list + a name map
+    python fetchers/opencorporates_relationships.py \\
+        --tickers-file scraper/basket_tickers.txt \\
+        --names-json some/ticker_to_name.json \\
+        --out out/opencorporates_subsidiaries.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+OC_API = "https://api.opencorporates.com/v0.4"
+
+# Delay between API calls (seconds). OpenCorporates doesn't publish a
+# hard per-second limit for paid tiers, but being polite avoids throttle
+# responses on bulk runs.
+DEFAULT_SLEEP_SEC = 0.5
+
+
+class RateLimited(Exception):
+    pass
+
+
+def oc_get(path: str, params: dict | None = None, api_key: str | None = None,
+           timeout: int = 30) -> dict:
+    """Thin wrapper around requests.get with error handling."""
+    params = dict(params or {})
+    if api_key:
+        params["api_token"] = api_key
+    r = requests.get(f"{OC_API}{path}", params=params, timeout=timeout)
+    if r.status_code == 429:
+        raise RateLimited(r.text)
+    if r.status_code >= 400:
+        raise RuntimeError(f"OC {path} → {r.status_code}: {r.text[:200]}")
+    return r.json()
+
+
+def search_company(name: str, api_key: str | None) -> dict | None:
+    """Return the best-match company record for a given legal name."""
+    resp = oc_get(
+        "/companies/search",
+        {
+            "q": name,
+            "per_page": 10,
+            "order": "score",
+            "inactive": "false",
+            "normalise_company_name": "true",
+        },
+        api_key=api_key,
+    )
+    companies = resp.get("results", {}).get("companies", [])
+    if not companies:
+        return None
+    # Prefer US jurisdictions (broadest for our ticker universe), then by
+    # rank-order from ElasticSearch. OC returns them score-ordered when
+    # order=score is passed.
+    companies.sort(
+        key=lambda c: (
+            0 if c["company"].get("jurisdiction_code", "").startswith("us") else 1,
+            0 if c["company"].get("current_status") == "Active" else 1,
+        )
+    )
+    return companies[0]["company"]
+
+
+def get_company_detail(jurisdiction: str, number: str,
+                       api_key: str | None) -> dict | None:
+    """GET full record for one company (includes controlling_entity)."""
+    try:
+        resp = oc_get(
+            f"/companies/{jurisdiction}/{number}",
+            {"sparse": "false"},
+            api_key=api_key,
+        )
+    except RuntimeError as e:
+        # 404 for companies sometimes returned as 403 — swallow
+        print(f"  !! detail fetch failed: {e}", file=sys.stderr)
+        return None
+    return resp.get("results", {}).get("company")
+
+
+def load_ticker_name_map(args: argparse.Namespace) -> dict[str, str]:
+    """Build the ticker → legal name map from whichever input was given."""
+    m: dict[str, str] = {}
+    if args.tickers_json:
+        # Expect the Wikidata output shape — has both ticker and name.
+        data = json.loads(Path(args.tickers_json).read_text())
+        for rec in data:
+            if rec.get("ticker") and rec.get("name"):
+                m[rec["ticker"].upper()] = rec["name"]
+            for sub_tkr in rec.get("subsidiaries", []):
+                m.setdefault(sub_tkr.upper(), sub_tkr)  # placeholder name
+    if args.names_json:
+        m.update({k.upper(): v for k, v in
+                  json.loads(Path(args.names_json).read_text()).items()})
+    if args.tickers_file:
+        # Plain list — we don't have a name, so use the ticker as a
+        # fallback query string. OC search tolerates this for big names
+        # but won't work great for obscure tickers.
+        for line in Path(args.tickers_file).read_text().splitlines():
+            t = line.strip().upper()
+            if t:
+                m.setdefault(t, t)
+    if not m:
+        raise SystemExit(
+            "No tickers provided. Pass --tickers-json, --tickers-file, or --names-json."
+        )
+    return m
+
+
+def load_checkpoint(out_path: Path) -> tuple[dict[str, set[str]], set[str]]:
+    """Load existing parent→subs map + the set of tickers already processed."""
+    if not out_path.exists():
+        return defaultdict(set), set()
+    try:
+        existing = json.loads(out_path.read_text())
+    except json.JSONDecodeError:
+        return defaultdict(set), set()
+
+    by_parent: dict[str, set[str]] = defaultdict(set)
+    processed: set[str] = set()
+    for rec in existing:
+        parent = rec["ticker"]
+        subs = rec.get("subsidiaries", [])
+        by_parent[parent].update(subs)
+        # Each entry in the output means we processed its `ticker`.
+        processed.add(parent)
+        # We also mark all *subsidiaries* as "already seen as a result" —
+        # but NOT as "processed" (we still need to query them for their
+        # own parent chain). Keep this distinction explicit.
+    return by_parent, processed
+
+
+def write_checkpoint(out_path: Path, by_parent: dict[str, set[str]]) -> None:
+    records = [
+        {"ticker": p, "subsidiaries": sorted(subs)}
+        for p, subs in sorted(by_parent.items())
+    ]
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(records, indent=2, ensure_ascii=False))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tickers-json", help="JSON in the wikidata_subsidiaries format (uses ticker+name)")
+    parser.add_argument("--tickers-file", help="plain ticker list, one per line")
+    parser.add_argument("--names-json",  help='JSON mapping {"TICKER": "Legal Name", ...}')
+    parser.add_argument("--out", default="out/opencorporates_subsidiaries.json",
+                        help="where to write / resume (default: out/opencorporates_subsidiaries.json)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="cap the number of new tickers processed this run (for rate-limit budget)")
+    parser.add_argument("--sleep", type=float, default=DEFAULT_SLEEP_SEC,
+                        help=f"seconds between API calls (default {DEFAULT_SLEEP_SEC})")
+    parser.add_argument("--upload-s3", action="store_true",
+                        help="push result to s3://ipickai-storage/metadata/ at the end")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("OPENCORPORATES_API_KEY")
+    if not api_key:
+        print("!! OPENCORPORATES_API_KEY not set — the free endpoint has a 500-call/month cap", file=sys.stderr)
+
+    ticker_to_name = load_ticker_name_map(args)
+    print(f"Loaded {len(ticker_to_name)} tickers to query")
+
+    out_path = Path(args.out)
+    by_parent, processed = load_checkpoint(out_path)
+    to_process = [t for t in ticker_to_name if t not in processed]
+    if args.limit:
+        to_process = to_process[: args.limit]
+
+    print(f"Resuming: {len(processed)} already processed, {len(to_process)} to go "
+          f"({'capped by --limit' if args.limit else 'full run'})")
+
+    try:
+        for i, ticker in enumerate(to_process, 1):
+            name = ticker_to_name[ticker]
+            try:
+                hit = search_company(name, api_key)
+                time.sleep(args.sleep)
+                if not hit:
+                    print(f"  [{i}/{len(to_process)}] {ticker}: no OC match for {name!r}")
+                    processed.add(ticker)
+                    continue
+
+                detail = get_company_detail(
+                    hit["jurisdiction_code"], hit["company_number"], api_key
+                )
+                time.sleep(args.sleep)
+                processed.add(ticker)
+
+                if not detail:
+                    continue
+
+                parent = detail.get("controlling_entity") or {}
+                parent_name = parent.get("name") if isinstance(parent, dict) else None
+                if not parent_name:
+                    # No known parent — not a subsidiary of anyone tracked
+                    continue
+
+                # Match the parent name back to a ticker in our known universe.
+                # Simple case-insensitive exact match against ticker_to_name.
+                parent_ticker = None
+                norm = parent_name.strip().lower()
+                for tkr, nm in ticker_to_name.items():
+                    if nm and nm.strip().lower() == norm:
+                        parent_ticker = tkr
+                        break
+                if not parent_ticker:
+                    # Parent is probably a private/foreign entity we don't
+                    # track — OC-only parents aren't useful for our graph.
+                    continue
+
+                by_parent[parent_ticker].add(ticker)
+                print(f"  [{i}/{len(to_process)}] {ticker} parent → {parent_ticker} ({parent_name})")
+
+            except RateLimited as e:
+                print(f"\n!! Rate-limited on {ticker}: {e}", file=sys.stderr)
+                print(f"   Checkpoint written to {out_path}. Re-run later to continue.")
+                break
+            except Exception as e:
+                print(f"  [{i}/{len(to_process)}] {ticker}: {e}", file=sys.stderr)
+                continue
+
+            # Periodic checkpoint — don't lose progress on Ctrl+C
+            if i % 25 == 0:
+                write_checkpoint(out_path, by_parent)
+    finally:
+        write_checkpoint(out_path, by_parent)
+
+    parent_count = len(by_parent)
+    total_subs = sum(len(s) for s in by_parent.values())
+    print(f"\nDone. {parent_count} parents, {total_subs} subsidiary edges → {out_path}")
+
+    if args.upload_s3:
+        import shutil
+        import subprocess
+        target = "s3://ipickai-storage/metadata/opencorporates_subsidiaries.json"
+        if shutil.which("aws"):
+            subprocess.run(["aws", "s3", "cp", str(out_path), target], check=True)
+            print(f"Uploaded → {target}")
+        else:
+            print(f"!! aws cli not found. Upload manually with:\n   aws s3 cp {out_path} {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fetchers/wikidata_subsidiaries.py
+++ b/fetchers/wikidata_subsidiaries.py
@@ -1,0 +1,174 @@
+"""
+Fetch public-to-public subsidiary relationships from Wikidata.
+
+Why: the SEC Exhibit 21.1 extractor produces lots of noise (country names,
+table headers, placeholder strings) because it naively captures both
+columns of the exhibit. Wikidata's structured relationships are cleaner
+— we query only for pairs where BOTH parent and subsidiary have a
+published ticker symbol, so there's no name-to-ticker reconciliation
+to worry about.
+
+Output schema matches what seed_supplier_subsidary.py expects:
+
+    [
+      {"ticker": "GOOGL", "subsidiaries": ["FIT", "WAZE", ...]},
+      ...
+    ]
+
+Values are already tickers (not names), so the seeder's exact-ticker
+match path handles them without any fuzzy resolution.
+
+Usage:
+    python fetchers/wikidata_subsidiaries.py                  # writes ./out/wikidata_subsidiaries.json
+    python fetchers/wikidata_subsidiaries.py --out some/path.json
+    python fetchers/wikidata_subsidiaries.py --upload-s3      # also push to ipickai-storage
+
+Wikidata SPARQL has no API key requirement. Soft rate limit is 1 query
+per 5 seconds from a given User-Agent; our one query runs in ~30s and
+returns a few thousand pairs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+WIKIDATA_ENDPOINT = "https://query.wikidata.org/sparql"
+
+# Be a good citizen: Wikidata asks for a descriptive User-Agent.
+USER_AGENT = "nexus-ipick/0.1 (https://github.com/andrewyzhou/nexus; ops@ipick.ai) requests/python"
+
+# Grab parent/subsidiary pairs where BOTH entities are publicly traded.
+#
+# We use ONLY P355 ("has subsidiary") rather than the looser P127
+# ("owned by") or P749 ("parent organization"). P127 conflates real
+# parent-subsidiary relationships with institutional shareholdings — if
+# BlackRock holds a >5% stake in Apple, Wikidata may encode Apple as
+# "owned by BlackRock" and produce an edge that isn't what we want
+# here. P355 is an explicit, directional subsidiary statement that's
+# much cleaner.
+#
+# Key detail: tickers in Wikidata are stored as qualifiers on the P414
+# ("stock exchange") statement, not as a direct P249 claim. Pattern:
+#     ?company p:P414 ?stmt .
+#     ?stmt pq:P249 ?ticker .
+SPARQL_QUERY = """
+SELECT DISTINCT ?parentTicker ?subTicker ?parentLabel ?subLabel WHERE {
+  ?parent wdt:P355 ?sub .
+  ?parent p:P414 ?parentStmt .
+  ?parentStmt pq:P249 ?parentTicker .
+  ?sub p:P414 ?subStmt .
+  ?subStmt pq:P249 ?subTicker .
+  FILTER (?parent != ?sub)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+"""
+
+
+def run_query() -> list[dict]:
+    """Execute the SPARQL query and return the raw bindings list."""
+    r = requests.get(
+        WIKIDATA_ENDPOINT,
+        params={"query": SPARQL_QUERY, "format": "json"},
+        headers={"User-Agent": USER_AGENT, "Accept": "application/sparql-results+json"},
+        timeout=60,
+    )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+def to_subsidiaries_json(bindings: list[dict]) -> list[dict]:
+    """Collapse the flat (parent, sub) pair list into the seeder's schema."""
+    by_parent: dict[str, set[str]] = defaultdict(set)
+    name_of: dict[str, str] = {}
+
+    for row in bindings:
+        p_tkr = row["parentTicker"]["value"].upper().strip()
+        s_tkr = row["subTicker"]["value"].upper().strip()
+
+        # Wikidata sometimes stores tickers with exchange prefixes like
+        # "NASDAQ: GOOGL" or with whitespace padding — strip both.
+        p_tkr = p_tkr.split(":")[-1].strip()
+        s_tkr = s_tkr.split(":")[-1].strip()
+
+        # Drop tickers that are purely numeric (Tokyo, HK, etc. exchanges
+        # that our companies table isn't likely to have) — keeps the
+        # output focused on the US-listed universe we actually seed.
+        if not p_tkr or not s_tkr or p_tkr == s_tkr:
+            continue
+        if p_tkr.isdigit() or s_tkr.isdigit():
+            continue
+
+        by_parent[p_tkr].add(s_tkr)
+        if p_tkr not in name_of and "parentLabel" in row:
+            name_of[p_tkr] = row["parentLabel"]["value"]
+        if s_tkr not in name_of and "subLabel" in row:
+            name_of[s_tkr] = row["subLabel"]["value"]
+
+    return [
+        {
+            "ticker": parent,
+            "name": name_of.get(parent),
+            "subsidiaries": sorted(subs),
+        }
+        for parent, subs in sorted(by_parent.items())
+    ]
+
+
+def maybe_upload_s3(path: Path) -> None:
+    """Push the output to ipickai-storage via aws cli if available."""
+    import shutil
+    import subprocess
+    target = "s3://ipickai-storage/metadata/wikidata_subsidiaries.json"
+    if shutil.which("aws"):
+        print(f"Uploading {path} → {target}")
+        subprocess.run(["aws", "s3", "cp", str(path), target], check=True)
+        return
+    try:
+        import boto3  # type: ignore
+        bucket, key = target.replace("s3://", "").split("/", 1)
+        boto3.client("s3").upload_file(str(path), bucket, key)
+        print(f"Uploaded via boto3: {target}")
+    except Exception as e:
+        print(f"!! S3 upload skipped ({e}). Upload manually with:")
+        print(f"   aws s3 cp {path} {target}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default="out/wikidata_subsidiaries.json",
+        help="where to write the resulting JSON (default: out/wikidata_subsidiaries.json)",
+    )
+    parser.add_argument(
+        "--upload-s3",
+        action="store_true",
+        help="also push the output to s3://ipickai-storage/metadata/",
+    )
+    args = parser.parse_args()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Querying Wikidata ({WIKIDATA_ENDPOINT})...")
+    bindings = run_query()
+    print(f"  got {len(bindings)} raw (parent, sub) ticker pairs")
+
+    records = to_subsidiaries_json(bindings)
+    total_subs = sum(len(r["subsidiaries"]) for r in records)
+    print(f"  collapsed into {len(records)} parents covering {total_subs} subsidiaries")
+
+    out_path.write_text(json.dumps(records, indent=2, ensure_ascii=False))
+    print(f"Wrote {out_path}")
+
+    if args.upload_s3:
+        maybe_upload_s3(out_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three alternative data sources for the relationships table, plus a merge tool. All output the same seeder-compatible JSON shape.

- **\`fetchers/wikidata_subsidiaries.py\`** — SPARQL on P355. ~580 real public-public ownership edges. Free, no key.
- **\`fetchers/dbpedia_subsidiaries.py\`** — SPARQL on dbo:subsidiary. ~12 edges, catches recent US acquisitions (CVS→OSH, INTC→MBLY, HPE→JNPR) Wikidata hasn't ingested. Free.
- **\`fetchers/opencorporates_relationships.py\`** — dormant unless OPENCORPORATES_API_KEY is set. Resumable, rate-limit-aware.
- **\`fetchers/merge_subsidiaries.py\`** — unions the above + writes a provenance sidecar (edges agreed on by multiple sources → higher confidence).

## Why

SEC Exhibit 21.1 extractor was producing ~135K "subsidiary" entries but only ~50 real edges landed, with false positives like \`Cadence → National Bank of Greece\` because the extractor confused the jurisdiction column with the entity column. Wikidata's structured data skips that noise entirely.

## Test plan

- [ ] \`python fetchers/wikidata_subsidiaries.py\` produces ~580 edges
- [ ] \`python fetchers/dbpedia_subsidiaries.py\` produces ~12 edges
- [ ] \`python fetchers/merge_subsidiaries.py\` combines both + writes \`.provenance.json\`
- [ ] Eventually: upload merged output to \`s3://ipickai-storage/metadata/subsidiaries.json\` and re-seed