### PR TITLE
refactor: rename 'subsidiary' relationship type to 'ownership'

### DIFF
--- a/backend/db/seed_supplier_subsidary.py
+++ b/backend/db/seed_supplier_subsidary.py
@@ -176,7 +176,7 @@ def seed_relationships():
                 if target == "NONE":
                     continue
                 
-                actual_target = resolve_target(target, skip_ticker_match=(rel_type == "subsidiary"))
+                actual_target = resolve_target(target, skip_ticker_match=(rel_type == "ownership"))
                 if not actual_target:
                     # Most subsidiary entries are legal entity names, not
                     # tickers — printing every unresolved target swamps
@@ -203,7 +203,10 @@ def seed_relationships():
     process_file(suppliers_path, "suppliers", "supplier")
 
     print("\nSeeding subsidiaries...")
-    process_file(subsidiaries_path, "subsidiaries", "subsidiary")
+    # 'ownership' (renamed from 'subsidiary') covers both majority and
+    # minority stakes — Wikidata P355 returns both, percentages are only
+    # present on ~20% of edges so we can't reliably threshold.
+    process_file(subsidiaries_path, "subsidiaries", "ownership")
 
     conn.commit()
     cursor.close()
@@ -212,7 +215,7 @@ def seed_relationships():
     print("\n" + "=" * 54)
     print("SEED COMPLETE")
     print("=" * 54)
-    print(f"Inserted {inserted_suppliers} supplier edges, {inserted_subsidiaries} subsidiary edges")
+    print(f"Inserted {inserted_suppliers} supplier edges, {inserted_subsidiaries} ownership edges")
     print(f"\nResolution breakdown:")
     print(f"  Resolved by exact ticker:        {_counts[0]}")
     print(f"  Resolved by exact name:          {_counts[1]}")

--- a/deploy/migrate-subsidiary-to-ownership.sql
+++ b/deploy/migrate-subsidiary-to-ownership.sql
@@ -1,0 +1,42 @@
+-- Rename existing 'subsidiary' edges to 'ownership' in the relationships
+-- table. Run once on the EC2 box after deploying the rename/subsidiary-
+-- to-ownership branch, or simply re-seed — ON CONFLICT DO NOTHING on the
+-- new INSERTs already handles the common case.
+--
+-- Idempotent: re-running is safe.
+--
+-- Run:
+--   sudo docker exec -i $(sudo docker ps -qf name=db) \
+--       psql -U nexus -d corporate_data -f - < deploy/migrate-subsidiary-to-ownership.sql
+
+BEGIN;
+
+-- Count before
+SELECT relationship_type, COUNT(*) AS before_count
+FROM relationships
+GROUP BY relationship_type
+ORDER BY before_count DESC;
+
+-- Rename. If an (source, target, 'ownership') row already exists for a
+-- given (source, target, 'subsidiary'), keep the existing one and drop
+-- the old subsidiary row (rare but possible if a previous seed ran both
+-- the old and new code paths).
+UPDATE relationships
+   SET relationship_type = 'ownership'
+ WHERE relationship_type = 'subsidiary'
+   AND NOT EXISTS (
+     SELECT 1 FROM relationships r2
+      WHERE r2.source_ticker = relationships.source_ticker
+        AND r2.target_ticker = relationships.target_ticker
+        AND r2.relationship_type = 'ownership'
+   );
+
+DELETE FROM relationships WHERE relationship_type = 'subsidiary';
+
+-- Count after
+SELECT relationship_type, COUNT(*) AS after_count
+FROM relationships
+GROUP BY relationship_type
+ORDER BY after_count DESC;
+
+COMMIT;

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -8,10 +8,14 @@ const API_BASE = (typeof window !== 'undefined' && window.NEXUS_API)
   || 'http://localhost:5001/nexus/api';
 
 // ── Edge colors by relationship type ─────────────────────────────────────────
+// Note: 'ownership' was previously 'subsidiary' — renamed because the data
+// covers both majority (true subsidiary) and minority (investor) stakes.
+// Wikidata P355 only has a quantity qualifier on ~20% of edges so we can't
+// reliably split the two; one label covers both cases.
 const EDGE_COLORS = {
-  competitor:  '#ef4444',  // red
-  supplier:    '#eab308',  // yellow
-  subsidiary:  '#3b82f6',  // blue
+  competitor: '#ef4444',  // red
+  supplier:   '#eab308',  // yellow
+  ownership:  '#3b82f6',  // blue
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -487,19 +491,19 @@ function loadPinnedRelationships(ticker, container) {
 
   Promise.all([
     fetch(`${API_BASE}/companies/${encodeURIComponent(ticker)}/neighbors?type=supplier`).then(r => r.ok ? r.json() : { edges: [] }),
-    fetch(`${API_BASE}/companies/${encodeURIComponent(ticker)}/neighbors?type=subsidiary`).then(r => r.ok ? r.json() : { edges: [] }),
+    fetch(`${API_BASE}/companies/${encodeURIComponent(ticker)}/neighbors?type=ownership`).then(r => r.ok ? r.json() : { edges: [] }),
   ]).then(([supData, subData]) => {
     const supplies_to  = (supData.edges  || []).filter(e => e.source === ticker).map(e => e.target);
     const supplied_by  = (supData.edges  || []).filter(e => e.target === ticker).map(e => e.source);
-    const subsidiaries = (subData.edges  || []).filter(e => e.source === ticker).map(e => e.target);
-    const parents      = (subData.edges  || []).filter(e => e.target === ticker).map(e => e.source);
+    const owns         = (subData.edges  || []).filter(e => e.source === ticker).map(e => e.target);
+    const owned_by     = (subData.edges  || []).filter(e => e.target === ticker).map(e => e.source);
 
     const sections = [
-      { label: 'Competitors',  color: EDGE_COLORS.competitor, tickers: competitors },
-      { label: 'Customers',    color: EDGE_COLORS.supplier,   tickers: supplies_to },
-      { label: 'Suppliers',    color: EDGE_COLORS.supplier,   tickers: supplied_by },
-      { label: 'Subsidiaries', color: EDGE_COLORS.subsidiary, tickers: subsidiaries },
-      { label: 'Parent',       color: EDGE_COLORS.subsidiary, tickers: parents },
+      { label: 'Competitors', color: EDGE_COLORS.competitor, tickers: competitors },
+      { label: 'Customers',   color: EDGE_COLORS.supplier,   tickers: supplies_to },
+      { label: 'Suppliers',   color: EDGE_COLORS.supplier,   tickers: supplied_by },
+      { label: 'Owns',        color: EDGE_COLORS.ownership,  tickers: owns },
+      { label: 'Owned by',    color: EDGE_COLORS.ownership,  tickers: owned_by },
     ].filter(s => s.tickers.length > 0);
 
     if (!sections.length) {
@@ -618,8 +622,8 @@ function buildEdgeLegend() {
     const item = document.createElement('div');
     item.className = 'edge-legend-item';
     const ARROW_LABELS = {
-      subsidiary: ['Parent', 'Subsidiary'],
-      supplier:   ['Supplier', 'Customer'],
+      ownership: ['Owner', 'Owned'],
+      supplier:  ['Supplier', 'Customer'],
     };
     const hasArrow = type in ARROW_LABELS;
     if (hasArrow) {
@@ -990,7 +994,7 @@ function renderGraph({ skipFit = false } = {}) {
     .attr('stroke', d => EDGE_COLORS[d.type] || '#888')
     .attr('stroke-width', 1.5)
     .attr('stroke-opacity', 1)
-    .attr('marker-end', d => (d.type === 'subsidiary' || d.type === 'supplier') ? `url(#arrow-${d.type})` : null);
+    .attr('marker-end', d => (d.type === 'ownership' || d.type === 'supplier') ? `url(#arrow-${d.type})` : null);
 
   const nodeEl = nodeGroup.selectAll('g')
     .data(visibleNodes)
@@ -1151,7 +1155,7 @@ function openPanel(d) {
       const node = isSource ? e.target : e.source;
       const tkr = typeof node === 'object' ? node.ticker : (allNodes.find(n => n.id === node)?.ticker || node);
       let role = e.type;
-      if (e.type === 'subsidiary') role = isSource ? 'Parent Of' : 'Subsidiary Of';
+      if (e.type === 'ownership') role = isSource ? 'Owns' : 'Owned By';
       if (e.type === 'supplier')   role = isSource ? 'Supplier Of' : 'Customer Of';
       return { ticker: tkr, role };
     });
@@ -1279,8 +1283,8 @@ function openPanel(d) {
     const groups = {
       'Supplier Of': [],
       'Customer Of': [],
-      'Subsidiary Of': [],
-      'Parent Of': []
+      'Owned By': [],
+      'Owns': []
     };
 
     unique.forEach(e => {
@@ -1346,12 +1350,12 @@ function openPanel(d) {
   updateTabs(graphConnections);
 
   Promise.all([
-    fetch(`${API_BASE}/companies/${encodeURIComponent(d.ticker)}/neighbors?type=subsidiary`).then(r => r.ok ? r.json() : { edges: [] }),
+    fetch(`${API_BASE}/companies/${encodeURIComponent(d.ticker)}/neighbors?type=ownership`).then(r => r.ok ? r.json() : { edges: [] }),
     fetch(`${API_BASE}/companies/${encodeURIComponent(d.ticker)}/neighbors?type=supplier`).then(r => r.ok ? r.json() : { edges: [] }),
   ]).then(([subData, supData]) => {
     const extra = [
-      ...(subData.edges || []).filter(e => e.source === d.ticker).map(e => ({ role: 'Parent Of',    ticker: e.target })),
-      ...(subData.edges || []).filter(e => e.target === d.ticker).map(e => ({ role: 'Subsidiary Of', ticker: e.source })),
+      ...(subData.edges || []).filter(e => e.source === d.ticker).map(e => ({ role: 'Owns',         ticker: e.target })),
+      ...(subData.edges || []).filter(e => e.target === d.ticker).map(e => ({ role: 'Owned By',     ticker: e.source })),
       ...(supData.edges || []).filter(e => e.source === d.ticker).map(e => ({ role: 'Supplier Of',  ticker: e.target })),
       ...(supData.edges || []).filter(e => e.target === d.ticker).map(e => ({ role: 'Customer Of',  ticker: e.source })),
     ];


### PR DESCRIPTION
## Summary

Rename the \`subsidiary\` relationship_type to \`ownership\` everywhere. The data from Wikidata P355 + SEC covers both majority (true subsidiary) and minority (investor) stakes, with percentage qualifiers present on only ~20% of edges — not enough to reliably split. \`ownership\` honestly covers both cases.

## What changes

- **Backend**: \`seed_supplier_subsidary.py\` inserts \`'ownership'\` and summarizes as "N ownership edges".
- **Frontend**: \`EDGE_COLORS.ownership\`, \`?type=ownership\` fetches, legend labels "Owner/Owned", detail-panel sections "Owns"/"Owned by" (replacing "Parent Of"/"Subsidiary Of").
- **Migration**: \`deploy/migrate-subsidiary-to-ownership.sql\` — idempotent one-shot to relabel existing rows.

## Deploy after merge

\`\`\`bash
# on the box
cd /home/ubuntu/nexus && git pull origin main
sudo docker exec -i \$(sudo docker ps -qf name=db) \\
    psql -U nexus -d corporate_data -f - \\
    < deploy/migrate-subsidiary-to-ownership.sql
# (nexus.service auto-restarts via the CI/CD workflow)
\`\`\`

## Test plan

- [ ] Workflow auto-deploys on merge
- [ ] Migration SQL prints expected before/after counts
- [ ] Frontend renders ownership edges (blue arrows)
- [ ] Detail panel shows "Owns" / "Owned by" in lieu of old labels