### PR TITLE
fix(cleanup): Medium -2 spacing fix + CEO flag list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Nexus*.docx
 # Local scrub-audit records (contains removed SHAs, don't publish)
 .scrub-records/
 track_cleanup_report.md
+flag-for-ceo.txt


### PR DESCRIPTION
Small follow-up to #10. Adds the ' -2' → ' - 2' spacing fix to match Medium - 3 / Medium - 4 siblings, and drops a plain-text CEO flag list in the repo root (gitignored) capturing the ~7 tracks that need Huajun's review before we delete/merge.