### PR TITLE
feat(admin): v2 admin page with tabs, track expand, companies/issues views

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -793,6 +793,184 @@ def admin_delete_relationship(rel_id):
     return jsonify({"ok": True, "deleted_id": rel_id})
 
 
+# ── /admin: track↔company membership ────────────────────────────────────
+
+@api.route("/admin/tracks/<int:track_id>/companies")
+def admin_track_companies(track_id):
+    """Expand a track: list every company linked to it."""
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT c.ticker, c.name, c.sector, c.market_cap
+        FROM companies c
+        JOIN company_tracks ct ON ct.company_id = c.id
+        WHERE ct.track_id = %s
+        ORDER BY COALESCE(c.market_cap, 0) DESC, c.ticker
+    """, (track_id,))
+    rows = [
+        {"ticker": r[0], "name": r[1], "sector": r[2], "market_cap": r[3]}
+        for r in cursor.fetchall()
+    ]
+    conn.close()
+    return jsonify(rows)
+
+
+@api.route("/admin/tracks/<int:track_id>/companies", methods=["POST"])
+def admin_track_add_company(track_id):
+    """Body: {ticker: 'NVDA'}. Links ticker → track."""
+    body = request.get_json(force=True, silent=True) or {}
+    ticker = (body.get("ticker") or "").upper().strip()
+    if not ticker:
+        return jsonify({"error": "ticker required"}), 400
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM companies WHERE ticker = %s", (ticker,))
+    company = cursor.fetchone()
+    if not company:
+        conn.close()
+        return jsonify({"error": f"ticker {ticker!r} not in companies table"}), 404
+    cursor.execute("SELECT id FROM investment_tracks WHERE id = %s", (track_id,))
+    if not cursor.fetchone():
+        conn.close()
+        return jsonify({"error": "track not found"}), 404
+    cursor.execute("""
+        INSERT INTO company_tracks (track_id, company_id)
+        VALUES (%s, %s) ON CONFLICT DO NOTHING
+    """, (track_id, company[0]))
+    linked = cursor.rowcount > 0
+    conn.commit()
+    conn.close()
+    return jsonify({"ok": True, "ticker": ticker, "newly_linked": linked})
+
+
+@api.route("/admin/tracks/<int:track_id>/companies/<ticker>", methods=["DELETE"])
+def admin_track_remove_company(track_id, ticker):
+    ticker = ticker.upper().strip()
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM companies WHERE ticker = %s", (ticker,))
+    company = cursor.fetchone()
+    if not company:
+        conn.close()
+        return jsonify({"error": f"ticker {ticker!r} not found"}), 404
+    cursor.execute(
+        "DELETE FROM company_tracks WHERE track_id = %s AND company_id = %s",
+        (track_id, company[0]),
+    )
+    removed = cursor.rowcount
+    conn.commit()
+    conn.close()
+    return jsonify({"ok": True, "ticker": ticker, "removed_links": removed})
+
+
+# ── /admin: company-side views ──────────────────────────────────────────
+
+@api.route("/admin/companies")
+def admin_list_companies():
+    """Paginated company list with their track membership.
+    Query: ?q=<search>&limit=N&offset=N"""
+    q = (request.args.get("q") or "").strip()
+    limit = min(request.args.get("limit", default=200, type=int), 1000)
+    offset = request.args.get("offset", default=0, type=int)
+    conn = get_conn()
+    cursor = conn.cursor()
+    where, params = "", []
+    if q:
+        where = "WHERE c.ticker ILIKE %s OR c.name ILIKE %s"
+        params = [f"%{q}%", f"%{q}%"]
+    cursor.execute(f"""
+        SELECT c.id, c.ticker, c.name, c.sector, c.market_cap,
+               COALESCE(
+                 array_agg(json_build_object('id', t.id, 'name', t.name))
+                 FILTER (WHERE t.id IS NOT NULL),
+                 ARRAY[]::json[]
+               ) AS tracks
+        FROM companies c
+        LEFT JOIN company_tracks ct ON ct.company_id = c.id
+        LEFT JOIN investment_tracks t ON t.id = ct.track_id
+        {where}
+        GROUP BY c.id, c.ticker, c.name, c.sector, c.market_cap
+        ORDER BY COALESCE(c.market_cap, 0) DESC, c.ticker
+        LIMIT %s OFFSET %s
+    """, params + [limit, offset])
+    rows = [
+        {
+            "id": r[0], "ticker": r[1], "name": r[2], "sector": r[3],
+            "market_cap": r[4], "tracks": r[5],
+        }
+        for r in cursor.fetchall()
+    ]
+    cursor.execute(f"SELECT COUNT(*) FROM companies c {where}", params)
+    total = cursor.fetchone()[0]
+    conn.close()
+    return jsonify({"companies": rows, "total": total, "limit": limit, "offset": offset})
+
+
+# ── /admin: data-quality issue reports ──────────────────────────────────
+
+@api.route("/admin/issues/orphan-companies")
+def admin_orphan_companies():
+    """Companies not linked to any investment track."""
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT c.id, c.ticker, c.name, c.sector, c.market_cap
+        FROM companies c
+        LEFT JOIN company_tracks ct ON ct.company_id = c.id
+        WHERE ct.company_id IS NULL
+        ORDER BY COALESCE(c.market_cap, 0) DESC, c.ticker
+    """)
+    rows = [
+        {"id": r[0], "ticker": r[1], "name": r[2],
+         "sector": r[3], "market_cap": r[4]}
+        for r in cursor.fetchall()
+    ]
+    conn.close()
+    return jsonify(rows)
+
+
+@api.route("/admin/issues/multi-track-companies")
+def admin_multi_track_companies():
+    """Companies linked to more than one investment track (maybe-dupes)."""
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT c.ticker, c.name,
+               array_agg(json_build_object('id', t.id, 'name', t.name)
+                         ORDER BY t.name) AS tracks,
+               COUNT(*) AS n
+        FROM companies c
+        JOIN company_tracks ct ON ct.company_id = c.id
+        JOIN investment_tracks t ON t.id = ct.track_id
+        GROUP BY c.id, c.ticker, c.name
+        HAVING COUNT(*) > 1
+        ORDER BY n DESC, c.ticker
+    """)
+    rows = [
+        {"ticker": r[0], "name": r[1], "tracks": r[2], "track_count": r[3]}
+        for r in cursor.fetchall()
+    ]
+    conn.close()
+    return jsonify(rows)
+
+
+@api.route("/admin/issues/empty-tracks")
+def admin_empty_tracks():
+    """Tracks with zero companies — leftover from renames or source-data churn."""
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT t.id, t.name
+        FROM investment_tracks t
+        LEFT JOIN company_tracks ct ON ct.track_id = t.id
+        WHERE ct.track_id IS NULL
+        ORDER BY t.name
+    """)
+    rows = [{"id": r[0], "name": r[1]} for r in cursor.fetchall()]
+    conn.close()
+    return jsonify(rows)
+
+
 app.register_blueprint(api)
 
 

--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -1,4 +1,35 @@
-/* Admin page — layered on top of style.css + track.css */
+/* Admin page — layered on top of style.css + track.css. The admin-body
+   class overrides the track.css layout to use a full-height grid with
+   internal scrolling per panel, so the user doesn't scroll the whole
+   document past 1104 rows to reach the edges panel. */
+
+/* Override track.css's default body flow — admin uses internal scroll */
+.admin-body { height: 100vh; overflow: hidden; }
+.admin-body #header { flex-shrink: 0; }
+
+#admin-main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px 24px;
+  height: calc(100vh - var(--header-h));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.admin-hero {
+  margin-bottom: 12px;
+}
+.admin-hero h1 {
+  font-size: 22px;
+  margin: 2px 0 4px;
+  letter-spacing: -0.01em;
+}
+.admin-hero .track-eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
 
 .admin-notice {
   border: 1px solid rgba(239, 68, 68, 0.4);
@@ -6,11 +37,62 @@
   color: #fecaca;
   padding: 14px 18px;
   border-radius: 10px;
-  margin: 0 0 24px;
+  margin: 0 0 16px;
 }
 html[data-theme="light"] .admin-notice {
   color: #991b1b;
   background: rgba(239, 68, 68, 0.1);
+}
+
+.admin-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+.admin-tabs .tab {
+  background: transparent;
+  color: var(--text-secondary);
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 16px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.admin-tabs .tab:hover { color: var(--text-primary); }
+.admin-tabs .tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.tab-count {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 99px;
+}
+
+.admin-tab-panel {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.admin-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 10px;
+  flex-shrink: 0;
 }
 
 .admin-input {
@@ -18,52 +100,61 @@ html[data-theme="light"] .admin-notice {
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 5px 10px;
+  padding: 6px 10px;
   font-family: inherit;
   font-size: 13px;
   outline: none;
-  min-width: 160px;
+  min-width: 240px;
 }
 .admin-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-dim); }
 
-.admin-table-wrap { margin-top: 12px; }
+.admin-list {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+}
 
-.admin-table {
-  width: 100%;
-  border-collapse: collapse;
+.admin-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.admin-row:last-child { border-bottom: none; }
+.admin-row:hover { background: var(--bg-hover); }
+.admin-row.expanded { background: var(--bg-hover); }
+.admin-row .primary {
   font-size: 13px;
+  color: var(--text-primary);
 }
-.admin-table th,
-.admin-table td {
-  padding: 8px 10px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  text-align: left;
-}
-html[data-theme="light"] .admin-table th,
-html[data-theme="light"] .admin-table td {
-  border-color: rgba(20, 24, 40, 0.08);
-}
-.admin-table th {
+.admin-row .primary .sub {
+  display: block;
   font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--text-muted);
-  font-weight: 500;
+  margin-top: 2px;
 }
-.admin-table tr:hover td { background: rgba(255, 255, 255, 0.02); }
-html[data-theme="light"] .admin-table tr:hover td { background: #eef0f6; }
-
-.admin-table .inline-edit {
-  background: transparent;
-  border: 1px solid transparent;
-  color: inherit;
-  font: inherit;
-  width: 100%;
-  padding: 4px 6px;
-  border-radius: 4px;
+.admin-row .count-chip {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  color: var(--text-secondary);
+  min-width: 30px;
+  text-align: center;
 }
-.admin-table .inline-edit:hover { border-color: var(--border); }
-.admin-table .inline-edit:focus { border-color: var(--accent); background: var(--bg-raised); outline: none; }
+.admin-row .actions {
+  display: flex;
+  gap: 4px;
+}
 
 .admin-btn {
   background: transparent;
@@ -73,22 +164,138 @@ html[data-theme="light"] .admin-table tr:hover td { background: #eef0f6; }
   padding: 3px 8px;
   font-size: 11px;
   cursor: pointer;
-  margin-left: 4px;
+  white-space: nowrap;
 }
 .admin-btn:hover { color: var(--accent); border-color: var(--accent); }
 .admin-btn.danger { border-color: #ef444466; color: #ef4444; }
 .admin-btn.danger:hover { border-color: #ef4444; background: rgba(239, 68, 68, 0.08); }
 
+.inline-edit {
+  background: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  font: inherit;
+  padding: 3px 6px;
+  border-radius: 4px;
+  width: 100%;
+}
+.admin-row:hover .inline-edit { border-color: var(--border); }
+.inline-edit:focus { border-color: var(--accent); background: var(--bg-raised); outline: none; }
+
+.expand-body {
+  grid-column: 1 / -1;
+  padding: 6px 10px 14px;
+  border-top: 1px dashed var(--border);
+}
+.company-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.company-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  padding: 3px 6px 3px 10px;
+  border-radius: 99px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-primary);
+}
+.company-chip .chip-x {
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0 4px;
+  font-size: 12px;
+  border-radius: 50%;
+  transition: color 0.1s, background 0.1s;
+}
+.company-chip .chip-x:hover {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.12);
+}
+.company-chip .chip-name {
+  color: var(--text-muted);
+  font-family: var(--font-body);
+}
+.company-chip-add-wrap {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+.company-chip-add-wrap .admin-input {
+  min-width: 100px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 8px;
+}
+
+/* Companies tab */
+.company-row .ticker {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.company-row .track-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.company-row .track-tag {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.company-row .track-tag .chip-x {
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.company-row .track-tag .chip-x:hover { color: #ef4444; }
+
+/* Issues tab */
+.issues-columns {
+  flex: 1 1 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+.issues-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.issues-col h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.issues-col p { margin: 0 0 8px; }
+
 .add-edge-row {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-top: 18px;
-  padding: 14px;
-  border: 1px dashed rgba(255, 255, 255, 0.1);
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px dashed var(--border-bright);
   border-radius: 10px;
+  flex-shrink: 0;
 }
-html[data-theme="light"] .add-edge-row { border-color: rgba(20, 24, 40, 0.15); }
 
 .admin-toast {
   position: fixed;
@@ -103,4 +310,7 @@ html[data-theme="light"] .add-edge-row { border-color: rgba(20, 24, 40, 0.15); }
   z-index: 1000;
 }
 .admin-toast.error { border-color: #ef4444; color: #fecaca; }
+html[data-theme="light"] .admin-toast.error { color: #991b1b; }
 .admin-toast.ok    { border-color: #10b981; }
+
+.empty { padding: 14px; color: var(--text-muted); }

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -11,7 +11,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.14.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.14.0/firebase-auth-compat.js"></script>
 </head>
-<body class="track-body">
+<body class="track-body admin-body">
   <header id="header">
     <a href="index.html" class="logo logo-link">NEXUS</a>
     <div class="header-right">
@@ -22,37 +22,51 @@
     </div>
   </header>
 
-  <main id="track-main">
-    <section id="track-hero">
-      <div class="track-hero-inner">
-        <div class="track-eyebrow">Admin</div>
-        <h1 id="admin-title">Investment Tracks & Edges</h1>
-        <p id="admin-desc">Rename, merge, delete tracks. Edit edges by ticker. Changes are live — no staging.</p>
-      </div>
-    </section>
+  <main id="admin-main">
+    <div class="admin-hero">
+      <div class="track-eyebrow">Admin</div>
+      <h1>Nexus data editor</h1>
+      <p class="dim small">Tracks, companies, edges — changes are live, no staging. All writes are audited in <code>journalctl -u nexus</code>.</p>
+    </div>
 
     <div id="not-admin-notice" class="admin-notice" style="display:none">
       <strong>Not authorized.</strong>
       You're signed in as <code id="notice-email"></code>. Ask an existing admin to add your email to <code>NEXUS_ADMIN_EMAILS</code> on the box.
     </div>
 
-    <section id="track-section" id="tracks-panel">
-      <div class="section-head">
-        <h2>Tracks <span class="dim small" id="tracks-count"></span></h2>
-        <input id="tracks-filter" class="admin-input" placeholder="filter tracks…" />
+    <div id="admin-tabs" class="admin-tabs">
+      <button class="tab active" data-tab="tracks">Tracks <span id="count-tracks" class="tab-count">–</span></button>
+      <button class="tab"        data-tab="companies">Companies <span id="count-companies" class="tab-count">–</span></button>
+      <button class="tab"        data-tab="edges">Edges</button>
+      <button class="tab"        data-tab="issues">Issues <span id="count-issues" class="tab-count">–</span></button>
+    </div>
+
+    <!-- ── Tracks tab ───────────────────────────────────────────────────── -->
+    <section class="admin-tab-panel" data-tab="tracks">
+      <div class="admin-toolbar">
+        <input id="tracks-filter" class="admin-input" placeholder="filter tracks by name…" />
+        <span id="tracks-meta" class="dim small"></span>
       </div>
-      <div id="admin-tracks" class="admin-table-wrap">Loading…</div>
+      <div id="admin-tracks" class="admin-list">Loading…</div>
     </section>
 
-    <section id="track-section" id="edges-panel">
-      <div class="section-head">
-        <h2>Edges by ticker</h2>
-        <div>
-          <input id="edges-ticker" class="admin-input" placeholder="ticker, e.g. NVDA" />
-          <button id="edges-load" class="track-control-btn">Load</button>
-        </div>
+    <!-- ── Companies tab ────────────────────────────────────────────────── -->
+    <section class="admin-tab-panel" data-tab="companies" style="display:none">
+      <div class="admin-toolbar">
+        <input id="companies-search" class="admin-input" placeholder="search ticker or name…" />
+        <span id="companies-meta" class="dim small"></span>
       </div>
-      <div id="admin-edges" class="admin-table-wrap dim small">Enter a ticker to list its edges.</div>
+      <div id="admin-companies" class="admin-list">Type a query to search.</div>
+    </section>
+
+    <!-- ── Edges tab ────────────────────────────────────────────────────── -->
+    <section class="admin-tab-panel" data-tab="edges" style="display:none">
+      <div class="admin-toolbar">
+        <input id="edges-ticker" class="admin-input" placeholder="ticker e.g. NVDA" />
+        <button id="edges-load" class="track-control-btn">Load edges</button>
+      </div>
+
+      <div id="admin-edges" class="admin-list dim small">Enter a ticker to list its edges.</div>
 
       <div class="add-edge-row">
         <strong>Add edge:</strong>
@@ -65,6 +79,27 @@
           <option value="ownership" selected>ownership</option>
         </select>
         <button id="new-edge-add" class="track-control-btn">Add</button>
+      </div>
+    </section>
+
+    <!-- ── Issues tab ───────────────────────────────────────────────────── -->
+    <section class="admin-tab-panel" data-tab="issues" style="display:none">
+      <div class="issues-columns">
+        <div class="issues-col">
+          <h3>Orphan companies <span id="count-orphans" class="dim small">–</span></h3>
+          <p class="dim small">Companies not linked to any investment track.</p>
+          <div id="admin-orphans" class="admin-list">Loading…</div>
+        </div>
+        <div class="issues-col">
+          <h3>Multi-track companies <span id="count-multitrack" class="dim small">–</span></h3>
+          <p class="dim small">Companies linked to more than one track — possible duplicates that should be merged.</p>
+          <div id="admin-multitrack" class="admin-list">Loading…</div>
+        </div>
+        <div class="issues-col">
+          <h3>Empty tracks <span id="count-empty" class="dim small">–</span></h3>
+          <p class="dim small">Tracks with zero companies. Usually safe to delete.</p>
+          <div id="admin-empty" class="admin-list">Loading…</div>
+        </div>
       </div>
     </section>
   </main>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -1,14 +1,17 @@
 /**
- * admin.js — /nexus/admin.html page
+ * admin.js — /nexus/admin.html
  *
- * - Waits for window.nexusAuthReady (auth.js handles Firebase login)
- * - Hits /admin/whoami to check if the signed-in user is in the allowlist
- * - If yes: loads tracks + binds the CRUD controls
- * - If no: shows a "not authorized" notice with the user's email
+ * 4 tabs, each panel internally scrollable so the page itself never
+ * scrolls beyond the header + hero. Tabs:
+ *   - Tracks     : filter + expand-to-show-companies + rename/merge/delete
+ *   - Companies  : search + track-membership chips (click ✕ to unlink)
+ *   - Edges      : search by ticker + add/delete
+ *   - Issues     : orphan companies, multi-track dupes, empty tracks
  */
 const API_BASE = (typeof window !== 'undefined' && window.NEXUS_API)
   || 'http://localhost:5001/nexus/api';
 
+// ── Utils ────────────────────────────────────────────────────────────────
 function toast(message, kind = 'ok') {
   const el = document.createElement('div');
   el.className = `admin-toast ${kind}`;
@@ -23,223 +26,431 @@ function escapeHtml(s) {
   }[c]));
 }
 
-// ── Tracks table ─────────────────────────────────────────────────────────
-let ALL_TRACKS = [];
-let FILTER = '';
+function fmtMcap(n) {
+  if (n == null) return '';
+  if (n >= 1e12) return `$${(n / 1e12).toFixed(2)}T`;
+  if (n >= 1e9)  return `$${(n / 1e9).toFixed(1)}B`;
+  if (n >= 1e6)  return `$${(n / 1e6).toFixed(0)}M`;
+  return `$${n}`;
+}
 
-function renderTracksTable() {
+async function api(path, opts = {}) {
+  const res = await fetch(`${API_BASE}${path}`, opts);
+  let body = null;
+  try { body = await res.json(); } catch (_) {}
+  if (!res.ok) throw new Error(body?.error || `HTTP ${res.status}`);
+  return body;
+}
+
+// ── State ────────────────────────────────────────────────────────────────
+let ALL_TRACKS = [];
+let TRACK_FILTER = '';
+const TRACK_COMPANIES_CACHE = new Map();   // track_id → companies[]
+const EXPANDED_TRACKS = new Set();
+
+// ── Tracks tab ───────────────────────────────────────────────────────────
+async function loadTracks() {
+  ALL_TRACKS = await api('/admin/tracks');
+  document.getElementById('count-tracks').textContent = ALL_TRACKS.length;
+  renderTracks();
+}
+
+function renderTracks() {
   const wrap = document.getElementById('admin-tracks');
-  const q = FILTER.trim().toLowerCase();
+  const q = TRACK_FILTER.trim().toLowerCase();
   const rows = q
     ? ALL_TRACKS.filter(t => t.name.toLowerCase().includes(q))
     : ALL_TRACKS;
 
-  document.getElementById('tracks-count').textContent =
-    `${rows.length} shown${q ? ` (filtered from ${ALL_TRACKS.length})` : ''}`;
+  document.getElementById('tracks-meta').textContent =
+    `${rows.length}${q ? ` of ${ALL_TRACKS.length}` : ''} tracks`;
 
   if (rows.length === 0) {
     wrap.innerHTML = '<div class="empty">No tracks match.</div>';
     return;
   }
 
-  wrap.innerHTML = `
-    <table class="admin-table">
-      <thead>
-        <tr>
-          <th style="width:40%">Name</th>
-          <th>Description</th>
-          <th class="num">Companies</th>
-          <th style="width:220px">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        ${rows.map(t => `
-          <tr data-id="${t.id}">
-            <td><input class="inline-edit name" value="${escapeHtml(t.name)}" /></td>
-            <td><input class="inline-edit desc" placeholder="(no description)" value="${escapeHtml(t.description || '')}" /></td>
-            <td class="num">${t.company_count}</td>
-            <td>
-              <button class="admin-btn save">Save</button>
-              <button class="admin-btn merge">Merge →</button>
-              <button class="admin-btn danger delete">Delete</button>
-            </td>
-          </tr>
-        `).join('')}
-      </tbody>
-    </table>
-  `;
+  wrap.innerHTML = rows.map(t => `
+    <div class="admin-row${EXPANDED_TRACKS.has(t.id) ? ' expanded' : ''}" data-id="${t.id}">
+      <div class="primary">
+        <input class="inline-edit name" value="${escapeHtml(t.name)}" data-original="${escapeHtml(t.name)}" />
+      </div>
+      <span class="count-chip">${t.company_count}</span>
+      <div class="actions">
+        <button class="admin-btn save">Save name</button>
+        <button class="admin-btn merge">Merge →</button>
+        <button class="admin-btn danger delete">Delete</button>
+      </div>
+      ${EXPANDED_TRACKS.has(t.id) ? `<div class="expand-body" data-body-for="${t.id}">Loading companies…</div>` : ''}
+    </div>
+  `).join('');
 
-  wrap.querySelectorAll('tr[data-id]').forEach(row => {
+  wrap.querySelectorAll('.admin-row[data-id]').forEach(row => {
     const id = Number(row.dataset.id);
-    row.querySelector('.save').addEventListener('click', () => saveTrack(id, row));
-    row.querySelector('.merge').addEventListener('click', () => mergeTrack(id));
-    row.querySelector('.delete').addEventListener('click', () => deleteTrack(id));
+    // Click row (not a button/input) to expand
+    row.addEventListener('click', (e) => {
+      if (e.target.closest('button, input')) return;
+      toggleExpand(id);
+    });
+    row.querySelector('.save').addEventListener('click', e => { e.stopPropagation(); saveTrackName(id, row); });
+    row.querySelector('.merge').addEventListener('click', e => { e.stopPropagation(); mergeTrack(id); });
+    row.querySelector('.delete').addEventListener('click', e => { e.stopPropagation(); deleteTrack(id); });
+    if (EXPANDED_TRACKS.has(id)) loadTrackCompanies(id);
   });
 }
 
-async function loadTracks() {
-  const res = await fetch(`${API_BASE}/admin/tracks`);
-  if (!res.ok) {
-    toast(`loadTracks failed: ${res.status}`, 'error');
-    return;
-  }
-  ALL_TRACKS = await res.json();
-  renderTracksTable();
+async function toggleExpand(trackId) {
+  if (EXPANDED_TRACKS.has(trackId)) EXPANDED_TRACKS.delete(trackId);
+  else EXPANDED_TRACKS.add(trackId);
+  renderTracks();
 }
 
-async function saveTrack(id, row) {
-  const name = row.querySelector('.name').value.trim();
-  const description = row.querySelector('.desc').value;
-  const res = await fetch(`${API_BASE}/admin/tracks/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, description }),
-  });
-  const body = await res.json();
-  if (!res.ok) {
-    toast(body.error || `save failed: ${res.status}`, 'error');
-    return;
+async function loadTrackCompanies(trackId) {
+  const body = document.querySelector(`[data-body-for="${trackId}"]`);
+  if (!body) return;
+  try {
+    const companies = await api(`/admin/tracks/${trackId}/companies`);
+    TRACK_COMPANIES_CACHE.set(trackId, companies);
+    body.innerHTML = `
+      <div class="company-chips" data-track="${trackId}">
+        ${companies.map(c => `
+          <span class="company-chip" data-ticker="${escapeHtml(c.ticker)}">
+            ${escapeHtml(c.ticker)}
+            <span class="chip-name">${escapeHtml((c.name || '').slice(0, 32))}</span>
+            <span class="chip-x" title="Remove from this track">✕</span>
+          </span>
+        `).join('') || '<span class="dim small">No companies linked.</span>'}
+        <span class="company-chip-add-wrap">
+          <input class="admin-input add-ticker" placeholder="+ ticker" />
+          <button class="admin-btn add-company">Add</button>
+        </span>
+      </div>
+    `;
+    body.querySelectorAll('.chip-x').forEach(x => {
+      x.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const ticker = x.parentElement.dataset.ticker;
+        if (!confirm(`Remove ${ticker} from this track?`)) return;
+        try {
+          await api(`/admin/tracks/${trackId}/companies/${encodeURIComponent(ticker)}`, { method: 'DELETE' });
+          toast(`removed ${ticker}`);
+          // Refresh this track row's count + company list
+          await loadTracks();
+        } catch (err) { toast(err.message, 'error'); }
+      });
+    });
+    body.querySelector('.add-company').addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const input = body.querySelector('.add-ticker');
+      const ticker = input.value.trim().toUpperCase();
+      if (!ticker) return;
+      try {
+        const res = await api(`/admin/tracks/${trackId}/companies`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ticker }),
+        });
+        toast(res.newly_linked ? `added ${ticker}` : `${ticker} already linked`);
+        input.value = '';
+        await loadTracks();
+      } catch (err) { toast(err.message, 'error'); }
+    });
+  } catch (err) {
+    body.innerHTML = `<span class="dim small">Load failed: ${escapeHtml(err.message)}</span>`;
   }
-  toast(`saved "${name}"`);
-  await loadTracks();
+}
+
+async function saveTrackName(id, row) {
+  const input = row.querySelector('.name');
+  const name = input.value.trim();
+  const original = input.dataset.original;
+  if (!name || name === original) return;
+  try {
+    await api(`/admin/tracks/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    toast(`renamed to "${name}"`);
+    await loadTracks();
+  } catch (err) { toast(err.message, 'error'); }
 }
 
 async function mergeTrack(sourceId) {
-  const srcName = ALL_TRACKS.find(t => t.id === sourceId)?.name || `#${sourceId}`;
+  const src = ALL_TRACKS.find(t => t.id === sourceId);
   const input = prompt(
-    `Merge "${srcName}" into which other track?\n\n` +
-    `Enter the target track's exact name (case-insensitive match).`
+    `Merge "${src?.name}" into which other track?\n\n` +
+    `Type the target track's exact name (case-insensitive).`
   );
   if (!input) return;
   const target = ALL_TRACKS.find(t => t.name.toLowerCase() === input.trim().toLowerCase());
-  if (!target) {
-    toast(`no track matching "${input}"`, 'error');
-    return;
-  }
-  if (target.id === sourceId) {
-    toast('cannot merge a track into itself', 'error');
-    return;
-  }
-  if (!confirm(`Merge "${srcName}" into "${target.name}"?\n\n` +
-               `All ${ALL_TRACKS.find(t => t.id === sourceId)?.company_count || 0} ` +
-               `companies from "${srcName}" will move to "${target.name}". ` +
-               `"${srcName}" will be deleted. This cannot be undone.`)) return;
-  const res = await fetch(`${API_BASE}/admin/tracks/merge`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ source_id: sourceId, target_id: target.id }),
-  });
-  const body = await res.json();
-  if (!res.ok) { toast(body.error || `merge failed: ${res.status}`, 'error'); return; }
-  toast(`merged: ${body.moved} company links moved`);
-  await loadTracks();
+  if (!target) return toast(`no track matching "${input}"`, 'error');
+  if (target.id === sourceId) return toast('cannot merge into itself', 'error');
+  if (!confirm(`Merge "${src.name}" (${src.company_count} companies) into "${target.name}"?\n\n` +
+               `"${src.name}" will be deleted.`)) return;
+  try {
+    const r = await api('/admin/tracks/merge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_id: sourceId, target_id: target.id }),
+    });
+    toast(`merged: ${r.moved} links moved`);
+    await loadTracks();
+  } catch (err) { toast(err.message, 'error'); }
 }
 
 async function deleteTrack(id) {
-  const name = ALL_TRACKS.find(t => t.id === id)?.name || `#${id}`;
-  if (!confirm(`Delete track "${name}"?\n\nAll company→track links under it will be removed. Cannot be undone.`)) return;
-  const res = await fetch(`${API_BASE}/admin/tracks/${id}`, { method: 'DELETE' });
-  const body = await res.json();
-  if (!res.ok) { toast(body.error || 'delete failed', 'error'); return; }
-  toast(`deleted "${name}" (${body.unlinked_companies} links removed)`);
-  await loadTracks();
+  const t = ALL_TRACKS.find(x => x.id === id);
+  if (!confirm(`Delete "${t?.name}"?\n\n${t?.company_count} company links will be unlinked. Cannot be undone.`)) return;
+  try {
+    const r = await api(`/admin/tracks/${id}`, { method: 'DELETE' });
+    toast(`deleted "${t?.name}" (${r.unlinked_companies} unlinked)`);
+    await loadTracks();
+  } catch (err) { toast(err.message, 'error'); }
 }
 
-// ── Edges by ticker ──────────────────────────────────────────────────────
-async function loadEdges() {
-  const ticker = document.getElementById('edges-ticker').value.trim().toUpperCase();
-  if (!ticker) { toast('enter a ticker', 'error'); return; }
-  const res = await fetch(`${API_BASE}/admin/relationships?ticker=${encodeURIComponent(ticker)}`);
-  if (!res.ok) { toast(`load failed: ${res.status}`, 'error'); return; }
-  const edges = await res.json();
-  const wrap = document.getElementById('admin-edges');
-  if (edges.length === 0) {
-    wrap.innerHTML = `<div class="empty">No edges for ${escapeHtml(ticker)}.</div>`;
+// ── Companies tab ────────────────────────────────────────────────────────
+let COMPANIES_SEARCH = '';
+let COMPANIES_TIMER = null;
+
+async function loadCompanies() {
+  const wrap = document.getElementById('admin-companies');
+  const meta = document.getElementById('companies-meta');
+  if (!COMPANIES_SEARCH.trim()) {
+    wrap.innerHTML = '<div class="empty">Type a query to search.</div>';
+    meta.textContent = '';
     return;
   }
-  wrap.innerHTML = `
-    <table class="admin-table">
-      <thead>
-        <tr><th>Source</th><th>Target</th><th>Type</th><th style="width:80px">Actions</th></tr>
-      </thead>
-      <tbody>
-        ${edges.map(e => `
-          <tr data-id="${e.id}">
-            <td>${escapeHtml(e.source)}</td>
-            <td>${escapeHtml(e.target)}</td>
-            <td>${escapeHtml(e.type)}</td>
-            <td><button class="admin-btn danger delete-edge">Delete</button></td>
-          </tr>
-        `).join('')}
-      </tbody>
-    </table>
-  `;
-  wrap.querySelectorAll('.delete-edge').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const id = Number(btn.closest('tr').dataset.id);
-      if (!confirm(`Delete edge #${id}?`)) return;
-      const res = await fetch(`${API_BASE}/admin/relationships/${id}`, { method: 'DELETE' });
-      const body = await res.json();
-      if (!res.ok) { toast(body.error || 'delete failed', 'error'); return; }
-      toast(`deleted edge #${id}`);
-      loadEdges();
+  wrap.innerHTML = '<div class="empty">Searching…</div>';
+  try {
+    const r = await api(`/admin/companies?q=${encodeURIComponent(COMPANIES_SEARCH)}&limit=200`);
+    meta.textContent = `${r.companies.length} of ${r.total} matches`;
+    document.getElementById('count-companies').textContent = r.total;
+    if (r.companies.length === 0) {
+      wrap.innerHTML = '<div class="empty">No matches.</div>';
+      return;
+    }
+    wrap.innerHTML = r.companies.map(c => `
+      <div class="admin-row company-row" data-ticker="${escapeHtml(c.ticker)}">
+        <div class="primary">
+          <span class="ticker">${escapeHtml(c.ticker)}</span>
+          <span class="sub">${escapeHtml(c.name || '')} • ${escapeHtml(c.sector || '–')} • ${fmtMcap(c.market_cap)}</span>
+          <div class="track-tags">
+            ${c.tracks.map(t => `
+              <span class="track-tag" data-track-id="${t.id}">
+                ${escapeHtml(t.name)}
+                <span class="chip-x" title="Remove from this track">✕</span>
+              </span>
+            `).join('') || '<span class="dim small">no tracks — orphan company</span>'}
+          </div>
+        </div>
+        <span class="count-chip">${c.tracks.length}</span>
+        <div class="actions">
+          <span class="dim small">click ✕ to unlink</span>
+        </div>
+      </div>
+    `).join('');
+    wrap.querySelectorAll('.track-tag .chip-x').forEach(x => {
+      x.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const tag = x.closest('.track-tag');
+        const row = x.closest('.company-row');
+        const ticker = row.dataset.ticker;
+        const trackId = Number(tag.dataset.trackId);
+        if (!confirm(`Remove ${ticker} from this track?`)) return;
+        try {
+          await api(`/admin/tracks/${trackId}/companies/${encodeURIComponent(ticker)}`, { method: 'DELETE' });
+          toast(`unlinked ${ticker}`);
+          loadCompanies();
+        } catch (err) { toast(err.message, 'error'); }
+      });
     });
-  });
+  } catch (err) {
+    wrap.innerHTML = `<div class="empty">Error: ${escapeHtml(err.message)}</div>`;
+  }
+}
+
+// ── Edges tab ────────────────────────────────────────────────────────────
+async function loadEdges() {
+  const ticker = document.getElementById('edges-ticker').value.trim().toUpperCase();
+  if (!ticker) return toast('enter a ticker', 'error');
+  const wrap = document.getElementById('admin-edges');
+  try {
+    const edges = await api(`/admin/relationships?ticker=${encodeURIComponent(ticker)}`);
+    if (edges.length === 0) {
+      wrap.innerHTML = `<div class="empty">No edges for ${escapeHtml(ticker)}.</div>`;
+      return;
+    }
+    wrap.innerHTML = edges.map(e => `
+      <div class="admin-row" data-id="${e.id}">
+        <div class="primary">
+          <span class="ticker">${escapeHtml(e.source)}</span>
+          <span class="dim small"> → </span>
+          <span class="ticker">${escapeHtml(e.target)}</span>
+          <span class="sub">${escapeHtml(e.type)}</span>
+        </div>
+        <span class="count-chip">${escapeHtml(e.type)}</span>
+        <div class="actions">
+          <button class="admin-btn danger delete-edge">Delete</button>
+        </div>
+      </div>
+    `).join('');
+    wrap.querySelectorAll('.delete-edge').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = Number(btn.closest('.admin-row').dataset.id);
+        if (!confirm(`Delete edge #${id}?`)) return;
+        try {
+          await api(`/admin/relationships/${id}`, { method: 'DELETE' });
+          toast(`deleted edge #${id}`);
+          loadEdges();
+        } catch (err) { toast(err.message, 'error'); }
+      });
+    });
+  } catch (err) {
+    wrap.innerHTML = `<div class="empty">Error: ${escapeHtml(err.message)}</div>`;
+  }
 }
 
 async function addEdge() {
   const src  = document.getElementById('new-edge-src').value.trim().toUpperCase();
   const tgt  = document.getElementById('new-edge-tgt').value.trim().toUpperCase();
   const type = document.getElementById('new-edge-type').value;
-  if (!src || !tgt) { toast('source + target required', 'error'); return; }
-  const res = await fetch(`${API_BASE}/admin/relationships`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ source: src, target: tgt, type }),
+  if (!src || !tgt) return toast('source + target required', 'error');
+  try {
+    await api('/admin/relationships', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: src, target: tgt, type }),
+    });
+    toast(`added ${src} → ${tgt} (${type})`);
+    document.getElementById('new-edge-src').value = '';
+    document.getElementById('new-edge-tgt').value = '';
+    const cur = document.getElementById('edges-ticker').value.trim().toUpperCase();
+    if (cur === src || cur === tgt) loadEdges();
+  } catch (err) { toast(err.message, 'error'); }
+}
+
+// ── Issues tab ───────────────────────────────────────────────────────────
+async function loadIssues() {
+  const [orphans, multi, empty] = await Promise.all([
+    api('/admin/issues/orphan-companies').catch(_ => []),
+    api('/admin/issues/multi-track-companies').catch(_ => []),
+    api('/admin/issues/empty-tracks').catch(_ => []),
+  ]);
+
+  document.getElementById('count-orphans').textContent   = orphans.length;
+  document.getElementById('count-multitrack').textContent= multi.length;
+  document.getElementById('count-empty').textContent     = empty.length;
+  document.getElementById('count-issues').textContent    = orphans.length + multi.length + empty.length;
+
+  const orphansEl = document.getElementById('admin-orphans');
+  orphansEl.innerHTML = orphans.length === 0
+    ? '<div class="empty">No orphans ✓</div>'
+    : orphans.map(c => `
+        <div class="admin-row">
+          <div class="primary">
+            <span class="ticker">${escapeHtml(c.ticker)}</span>
+            <span class="sub">${escapeHtml(c.name || '')} • ${fmtMcap(c.market_cap)}</span>
+          </div>
+          <span class="count-chip">0</span>
+          <div class="actions">
+            <button class="admin-btn" onclick="(function(){document.querySelector('[data-tab=\\'companies\\']').click(); document.getElementById('companies-search').value='${escapeHtml(c.ticker)}'; document.getElementById('companies-search').dispatchEvent(new Event('input'));})()">Open</button>
+          </div>
+        </div>
+      `).join('');
+
+  const multiEl = document.getElementById('admin-multitrack');
+  multiEl.innerHTML = multi.length === 0
+    ? '<div class="empty">No multi-track companies ✓</div>'
+    : multi.map(c => `
+        <div class="admin-row">
+          <div class="primary">
+            <span class="ticker">${escapeHtml(c.ticker)}</span>
+            <span class="sub">${escapeHtml(c.name || '')}</span>
+            <div class="track-tags">
+              ${c.tracks.map(t => `<span class="track-tag">${escapeHtml(t.name)}</span>`).join('')}
+            </div>
+          </div>
+          <span class="count-chip">${c.track_count}</span>
+          <div class="actions"></div>
+        </div>
+      `).join('');
+
+  const emptyEl = document.getElementById('admin-empty');
+  emptyEl.innerHTML = empty.length === 0
+    ? '<div class="empty">No empty tracks ✓</div>'
+    : empty.map(t => `
+        <div class="admin-row" data-id="${t.id}">
+          <div class="primary">
+            <span>${escapeHtml(t.name)}</span>
+          </div>
+          <span class="count-chip">0</span>
+          <div class="actions">
+            <button class="admin-btn danger delete">Delete</button>
+          </div>
+        </div>
+      `).join('');
+  emptyEl.querySelectorAll('.delete').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = Number(btn.closest('.admin-row').dataset.id);
+      if (!confirm('Delete this empty track?')) return;
+      try {
+        await api(`/admin/tracks/${id}`, { method: 'DELETE' });
+        toast('deleted');
+        loadIssues();
+      } catch (err) { toast(err.message, 'error'); }
+    });
   });
-  const body = await res.json();
-  if (!res.ok) { toast(body.error || 'add failed', 'error'); return; }
-  toast(`added ${src} → ${tgt} (${type})`);
-  document.getElementById('new-edge-src').value = '';
-  document.getElementById('new-edge-tgt').value = '';
-  // Refresh the edges panel if the user is currently filtering by either endpoint
-  const current = document.getElementById('edges-ticker').value.trim().toUpperCase();
-  if (current === src || current === tgt) loadEdges();
+}
+
+// ── Tabs ─────────────────────────────────────────────────────────────────
+function switchTab(name) {
+  document.querySelectorAll('.admin-tabs .tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.tab === name);
+  });
+  document.querySelectorAll('.admin-tab-panel').forEach(p => {
+    p.style.display = p.dataset.tab === name ? '' : 'none';
+  });
+  if (name === 'issues') loadIssues();
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────
 async function init() {
   if (window.nexusAuthReady) await window.nexusAuthReady;
 
-  // whoami tells us if auth is required, who's signed in, and whether
-  // they're in the allowlist. Single source of truth for gating the UI.
-  const res = await fetch(`${API_BASE}/admin/whoami`).catch(() => null);
-  const badge = document.getElementById('admin-user-badge');
-
-  if (!res || !res.ok) {
-    // Dev mode: auth disabled and /admin/whoami returns 200 with no email;
-    // or prod with a non-admin user returning 403.
-    if (res && res.status === 403) {
+  let who;
+  try {
+    who = await api('/admin/whoami');
+  } catch (err) {
+    // 403 = signed in but not admin
+    if (String(err.message).includes('admin-only')) {
+      const res = await fetch(`${API_BASE}/admin/whoami`);
       const body = await res.json();
-      badge.textContent = body.user_email || 'signed in';
       document.getElementById('notice-email').textContent = body.user_email || '(no email)';
       document.getElementById('not-admin-notice').style.display = '';
-      document.getElementById('tracks-panel')?.remove();
-      document.getElementById('edges-panel')?.remove();
+      document.getElementById('admin-tabs').style.display = 'none';
+      document.querySelectorAll('.admin-tab-panel').forEach(p => p.style.display = 'none');
       return;
     }
-    badge.textContent = 'unreachable';
-    toast(`whoami failed: ${res?.status || 'no response'}`, 'error');
+    toast(err.message, 'error');
     return;
   }
 
-  const who = await res.json();
-  badge.textContent = who.email ? `${who.email} • admin` : 'dev mode (auth off)';
+  document.getElementById('admin-user-badge').textContent =
+    who.email ? `${who.email} • admin` : 'dev mode (auth off)';
 
-  // Wire up controls
+  // Wire controls
+  document.querySelectorAll('.admin-tabs .tab').forEach(t => {
+    t.addEventListener('click', () => switchTab(t.dataset.tab));
+  });
   document.getElementById('tracks-filter').addEventListener('input', e => {
-    FILTER = e.target.value;
-    renderTracksTable();
+    TRACK_FILTER = e.target.value;
+    renderTracks();
+  });
+  document.getElementById('companies-search').addEventListener('input', e => {
+    COMPANIES_SEARCH = e.target.value;
+    clearTimeout(COMPANIES_TIMER);
+    COMPANIES_TIMER = setTimeout(loadCompanies, 250);  // debounce
   });
   document.getElementById('edges-load').addEventListener('click', loadEdges);
   document.getElementById('edges-ticker').addEventListener('keydown', e => {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -315,8 +315,19 @@ html[data-theme="light"] .track-control-btn {
   border: 1px solid var(--border-bright);
   border-radius: var(--radius-sm);
   z-index: 200;
-  overflow: hidden;
+  /* Cap height to ~45% viewport so long result lists scroll internally
+     instead of running off the sidebar. */
+  max-height: 45vh;
+  overflow-y: auto;
+  overflow-x: hidden;
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+}
+/* Group headers sticky so you can see which section you're scrolling */
+.search-dropdown-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-surface);
 }
 .search-dropdown-header {
   font-family: var(--font-mono);


### PR DESCRIPTION
See commit message. Fixes all the v1 feedback: no more 100-row scroll before reaching edges, track expand shows member companies with add/remove, companies tab makes orphans obvious, issues tab surfaces multi-track dupes and empty-track cleanup candidates. Also caps sidebar-search dropdown at 45vh with internal scroll.