### PR TITLE
fix(admin): show full alphabetical company list

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1112,10 +1112,16 @@ def admin_track_remove_company(track_id, ticker):
 @api.route("/admin/companies")
 def admin_list_companies():
     """Paginated company list with their track membership.
-    Query: ?q=<search>&limit=N&offset=N"""
+    Query: ?q=<search>&limit=N&offset=N&sort=ticker|name|market_cap"""
     q = (request.args.get("q") or "").strip()
-    limit = min(request.args.get("limit", default=200, type=int), 1000)
+    limit = min(request.args.get("limit", default=5000, type=int), 10000)
     offset = request.args.get("offset", default=0, type=int)
+    sort = request.args.get("sort", default="ticker")
+    order_by = {
+        "ticker": "c.ticker ASC",
+        "name": "c.name ASC NULLS LAST, c.ticker ASC",
+        "market_cap": "COALESCE(c.market_cap, 0) DESC, c.ticker",
+    }.get(sort, "c.ticker ASC")
     conn = get_conn()
     cursor = conn.cursor()
     where, params = "", []
@@ -1134,7 +1140,7 @@ def admin_list_companies():
         LEFT JOIN investment_tracks t ON t.id = ct.track_id
         {where}
         GROUP BY c.id, c.ticker, c.name, c.sector, c.market_cap
-        ORDER BY COALESCE(c.market_cap, 0) DESC, c.ticker
+        ORDER BY {order_by}
         LIMIT %s OFFSET %s
     """, params + [limit, offset])
     rows = [

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -216,15 +216,12 @@ let COMPANIES_TIMER = null;
 async function loadCompanies() {
   const wrap = document.getElementById('admin-companies');
   const meta = document.getElementById('companies-meta');
-  if (!COMPANIES_SEARCH.trim()) {
-    wrap.innerHTML = '<div class="empty">Type a query to search.</div>';
-    meta.textContent = '';
-    return;
-  }
-  wrap.innerHTML = '<div class="empty">Searching…</div>';
+  wrap.innerHTML = '<div class="empty">Loading…</div>';
   try {
-    const r = await api(`/admin/companies?q=${encodeURIComponent(COMPANIES_SEARCH)}&limit=200`);
-    meta.textContent = `${r.companies.length} of ${r.total} matches`;
+    const r = await api(`/admin/companies?q=${encodeURIComponent(COMPANIES_SEARCH)}&limit=10000&sort=ticker`);
+    meta.textContent = COMPANIES_SEARCH.trim()
+      ? `${r.companies.length} of ${r.total} matches`
+      : `${r.companies.length} companies`;
     document.getElementById('count-companies').textContent = r.total;
     if (r.companies.length === 0) {
       wrap.innerHTML = '<div class="empty">No matches.</div>';
@@ -412,6 +409,7 @@ function switchTab(name) {
     p.style.display = p.dataset.tab === name ? '' : 'none';
   });
   if (name === 'issues') loadIssues();
+  if (name === 'companies') loadCompanies();
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `/admin/companies` defaulted to `market_cap DESC LIMIT 200`, so Q/R/S/T mid-caps fell off the cut and the admin Companies tab visibly jumped from P to U while scrolling.
- Backend now accepts `sort=ticker|name|market_cap` (default `ticker`) and a higher default/cap (5000 / 10000).
- Frontend loads the full list on tab open and uses the search box as a filter.

## Test plan
- [ ] Open admin → Companies tab, scroll through Q/R/S/T — companies present
- [ ] Type a ticker/name prefix — filters in place, meta shows "N of M matches"

🤖 Generated with [Claude Code](https://claude.com/claude-code)