### PR TITLE
feat(admin): paginate Companies tab

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1114,7 +1114,7 @@ def admin_list_companies():
     """Paginated company list with their track membership.
     Query: ?q=<search>&limit=N&offset=N&sort=ticker|name|market_cap"""
     q = (request.args.get("q") or "").strip()
-    limit = min(request.args.get("limit", default=5000, type=int), 10000)
+    limit = min(request.args.get("limit", default=100, type=int), 10000)
     offset = request.args.get("offset", default=0, type=int)
     sort = request.args.get("sort", default="ticker")
     order_by = {

--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -314,3 +314,16 @@ html[data-theme="light"] .admin-toast.error { color: #991b1b; }
 .admin-toast.ok    { border-color: #10b981; }
 
 .empty { padding: 14px; color: var(--text-muted); }
+
+.admin-pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0 2px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.admin-pager button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -54,9 +54,25 @@
     <section class="admin-tab-panel" data-tab="companies" style="display:none">
       <div class="admin-toolbar">
         <input id="companies-search" class="admin-input" placeholder="search ticker or name…" />
+        <select id="companies-sort" class="admin-input">
+          <option value="ticker">Sort: ticker A→Z</option>
+          <option value="name">Sort: name A→Z</option>
+          <option value="market_cap">Sort: market cap ↓</option>
+        </select>
         <span id="companies-meta" class="dim small"></span>
       </div>
-      <div id="admin-companies" class="admin-list">Type a query to search.</div>
+      <div id="admin-companies" class="admin-list">Loading…</div>
+      <div id="companies-pager" class="admin-pager" style="display:none">
+        <button class="track-control-btn" id="pg-first">« first</button>
+        <button class="track-control-btn" id="pg-prev">‹ prev</button>
+        <span id="pg-info" class="dim small"></span>
+        <button class="track-control-btn" id="pg-next">next ›</button>
+        <button class="track-control-btn" id="pg-last">last »</button>
+        <label class="dim small">
+          jump to
+          <input id="pg-jump" class="admin-input" style="width:64px" type="number" min="1" />
+        </label>
+      </div>
     </section>
 
     <!-- ── Edges tab ────────────────────────────────────────────────────── -->

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -210,18 +210,42 @@ async function deleteTrack(id) {
 }
 
 // ── Companies tab ────────────────────────────────────────────────────────
+const COMPANIES_PAGE_SIZE = 100;
 let COMPANIES_SEARCH = '';
+let COMPANIES_SORT = 'ticker';
+let COMPANIES_PAGE = 1;   // 1-indexed
 let COMPANIES_TIMER = null;
 
 async function loadCompanies() {
   const wrap = document.getElementById('admin-companies');
   const meta = document.getElementById('companies-meta');
+  const pager = document.getElementById('companies-pager');
   wrap.innerHTML = '<div class="empty">Loading…</div>';
   try {
-    const r = await api(`/admin/companies?q=${encodeURIComponent(COMPANIES_SEARCH)}&limit=10000&sort=ticker`);
+    const offset = (COMPANIES_PAGE - 1) * COMPANIES_PAGE_SIZE;
+    const r = await api(
+      `/admin/companies?q=${encodeURIComponent(COMPANIES_SEARCH)}` +
+      `&limit=${COMPANIES_PAGE_SIZE}&offset=${offset}&sort=${COMPANIES_SORT}`
+    );
+    const totalPages = Math.max(1, Math.ceil(r.total / COMPANIES_PAGE_SIZE));
+    // Clamp + retry if we landed past the end (e.g. search narrowed results)
+    if (COMPANIES_PAGE > totalPages) {
+      COMPANIES_PAGE = totalPages;
+      return loadCompanies();
+    }
     meta.textContent = COMPANIES_SEARCH.trim()
-      ? `${r.companies.length} of ${r.total} matches`
-      : `${r.companies.length} companies`;
+      ? `${r.total} matches`
+      : `${r.total} companies`;
+    pager.style.display = r.total > COMPANIES_PAGE_SIZE ? 'flex' : 'none';
+    const startN = r.total === 0 ? 0 : offset + 1;
+    const endN = Math.min(offset + r.companies.length, r.total);
+    document.getElementById('pg-info').textContent =
+      `page ${COMPANIES_PAGE} of ${totalPages} · showing ${startN}–${endN}`;
+    document.getElementById('pg-prev').disabled  = COMPANIES_PAGE <= 1;
+    document.getElementById('pg-first').disabled = COMPANIES_PAGE <= 1;
+    document.getElementById('pg-next').disabled  = COMPANIES_PAGE >= totalPages;
+    document.getElementById('pg-last').disabled  = COMPANIES_PAGE >= totalPages;
+    document.getElementById('pg-jump').max = totalPages;
     document.getElementById('count-companies').textContent = r.total;
     if (r.companies.length === 0) {
       wrap.innerHTML = '<div class="empty">No matches.</div>';
@@ -447,8 +471,22 @@ async function init() {
   });
   document.getElementById('companies-search').addEventListener('input', e => {
     COMPANIES_SEARCH = e.target.value;
+    COMPANIES_PAGE = 1;
     clearTimeout(COMPANIES_TIMER);
     COMPANIES_TIMER = setTimeout(loadCompanies, 250);  // debounce
+  });
+  document.getElementById('companies-sort').addEventListener('change', e => {
+    COMPANIES_SORT = e.target.value;
+    COMPANIES_PAGE = 1;
+    loadCompanies();
+  });
+  document.getElementById('pg-first').addEventListener('click', () => { COMPANIES_PAGE = 1; loadCompanies(); });
+  document.getElementById('pg-prev' ).addEventListener('click', () => { COMPANIES_PAGE = Math.max(1, COMPANIES_PAGE - 1); loadCompanies(); });
+  document.getElementById('pg-next' ).addEventListener('click', () => { COMPANIES_PAGE += 1; loadCompanies(); });
+  document.getElementById('pg-last' ).addEventListener('click', () => { COMPANIES_PAGE = Number(document.getElementById('pg-jump').max) || 1; loadCompanies(); });
+  document.getElementById('pg-jump' ).addEventListener('change', e => {
+    const n = Number(e.target.value);
+    if (Number.isFinite(n) && n >= 1) { COMPANIES_PAGE = n; loadCompanies(); }
   });
   document.getElementById('edges-load').addEventListener('click', loadEdges);
   document.getElementById('edges-ticker').addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- Companies tab now paginated: 100 per page, first/prev/next/last + jump-to-page controls.
- Sort selector: ticker A→Z (default), name A→Z, market cap ↓.
- Backend default limit returns to 100 (was bumped to 5000 in #19 as a stopgap).

## Test plan
- [ ] Open admin → Companies: first page loads, pager shows "page 1 of N"
- [ ] next/prev/first/last navigate pages
- [ ] Jump box clamps to totalPages
- [ ] Typing a search resets to page 1; pager hides when total ≤ 100
- [ ] Q/R/S/T companies reachable by paging or by typing in the search box

🤖 Generated with [Claude Code](https://claude.com/claude-code)