### PR TITLE
Route backend news summaries through AI pipeline

### DIFF
--- a/ai/pipeline/news_scraper.py
+++ b/ai/pipeline/news_scraper.py
@@ -427,7 +427,7 @@ class NewsScraper:
         self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
     ) -> list[dict[str, object]]:
         """Tier 2: RSS feeds (myFT / Google News fallback)."""
-        results: list[str] = []
+        results: list[dict[str, object]] = []
 
         if self.myft_rss_url:
             try:

--- a/ai/pipeline/news_scraper.py
+++ b/ai/pipeline/news_scraper.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import re
+from dataclasses import asdict, dataclass
 from email.utils import parsedate_to_datetime
 from urllib.parse import parse_qsl, quote_plus, urlencode, urlsplit, urlunsplit
 
@@ -19,6 +20,18 @@ try:
     import yfinance as yf
 except ImportError:
     yf = None
+
+
+@dataclass
+class ArticleRecord:
+    title: str
+    source: str
+    url: str
+    published: str | None
+    summary: str
+    text: str
+    score: float
+    ticker: str
 
 
 class NewsScraper:
@@ -210,7 +223,79 @@ class NewsScraper:
         )
         return score >= 0.5
 
-    def _select_top_candidates(self, candidates: list[dict[str, object]], k: int = 2) -> list[str]:
+    def _to_article_record(
+        self,
+        *,
+        ticker: str,
+        title: str,
+        source: str,
+        url: str,
+        text: str,
+        score: float,
+        published_at: datetime | None = None,
+        summary: str = "",
+    ) -> dict[str, object]:
+        published = None
+        if published_at is not None:
+            dt = published_at if published_at.tzinfo else published_at.replace(tzinfo=timezone.utc)
+            published = dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        return asdict(
+            ArticleRecord(
+                title=title or "",
+                source=source or "Unknown",
+                url=(url or "").strip(),
+                published=published,
+                summary=(summary or "").strip(),
+                text=(text or "").strip(),
+                score=float(score or 0.0),
+                ticker=ticker.upper().strip(),
+            )
+        )
+
+    def _summarize_text(self, text: str, max_chars: int = 220) -> str:
+        words = (text or "").split()
+        if not words:
+            return ""
+        excerpt = " ".join(words[:35]).strip()
+        if len(excerpt) > max_chars:
+            excerpt = excerpt[: max_chars - 3].rstrip()
+        return f"{excerpt}..." if excerpt and len(words) > 35 else excerpt
+
+    def _serialize_article(self, article: dict[str, object]) -> str:
+        if isinstance(article, str):
+            return article
+        return (
+            f"Title: {article.get('title', '')}\n"
+            f"Source: {article.get('source', 'Unknown')}\n"
+            f"Published: {article.get('published', '')}\n"
+            f"Summary: {article.get('summary', '')}\n"
+            f"URL: {article.get('url', '')}\n"
+            f"Text: {article.get('text', '')}"
+        )
+
+    def serialize_articles(self, articles: list[dict[str, object]]) -> str:
+        return "\n\n---\n\n".join(self._serialize_article(article) for article in articles)
+
+    def _legacy_block_to_article(self, article: str, ticker: str) -> dict[str, object]:
+        def _match(pattern: str) -> str:
+            found = re.search(pattern, article, flags=re.MULTILINE)
+            return found.group(1).strip() if found else ""
+
+        text = _match(r"^Text:\s*(.*)$")
+        return self._to_article_record(
+            ticker=ticker,
+            title=_match(r"^Title:\s*(.*)$"),
+            source=_match(r"^Source:\s*(.*)$") or "Unknown",
+            url=_match(r"^URL:\s*(.*)$"),
+            text=text,
+            summary=self._summarize_text(text),
+            score=0.0,
+            published_at=self._coerce_datetime(_match(r"^Published:\s*(.*)$")),
+        )
+
+    def _select_top_candidates(
+        self, candidates: list[dict[str, object]], k: int = 2
+    ) -> list[dict[str, object]]:
         if not candidates:
             return []
 
@@ -222,21 +307,10 @@ class NewsScraper:
                 continue
             prior = dedup.get(key)
             if prior is None or float(c.get("score", 0.0) or 0.0) > float(prior.get("score", 0.0) or 0.0):
-                c["url"] = url
                 dedup[key] = c
 
         ranked = sorted(dedup.values(), key=lambda x: float(x.get("score", 0.0) or 0.0), reverse=True)
-        out: list[str] = []
-        for row in ranked[: max(1, k)]:
-            out.append(
-                (
-                    f"Title: {row.get('title', '')}\n"
-                    f"Source: {row.get('source', 'Unknown')}\n"
-                    f"URL: {row.get('url', '')}\n"
-                    f"Text: {row.get('text', '')}"
-                )
-            )
-        return out
+        return ranked[: max(1, k)]
 
     async def fetch_full_text(self, session: aiohttp.ClientSession, url: str | None) -> str:
         """Use Trafilatura to extract body text from an article URL."""
@@ -264,7 +338,7 @@ class NewsScraper:
     )
     async def fetch_yfinance_tier(
         self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
-    ) -> list[str]:
+    ) -> list[dict[str, object]]:
         """Tier 1: yfinance news ingestion."""
         if not yf:
             raise ValueError("yfinance not installed")
@@ -293,6 +367,7 @@ class NewsScraper:
             publisher = content.get("publisher")
             if not publisher and content.get("provider"):
                 publisher = content.get("provider", {}).get("displayName")
+            source_summary = (content.get("summary") or content.get("description") or "").strip()
             published_at = self._coerce_datetime(
                 content.get("providerPublishTime")
                 or content.get("pubDate")
@@ -313,12 +388,15 @@ class NewsScraper:
                 source=publisher,
                 published_at=published_at,
             ):
-                return {
-                    "title": title or "",
-                    "source": publisher or "Yahoo Finance",
-                    "url": link,
-                    "text": text,
-                    "score": self._relevance_score(
+                return self._to_article_record(
+                    ticker=ticker,
+                    title=title or "",
+                    source=publisher or "Yahoo Finance",
+                    url=link,
+                    text=text,
+                    published_at=published_at,
+                    summary=source_summary or self._summarize_text(text),
+                    score=self._relevance_score(
                         text,
                         title or "",
                         ticker,
@@ -326,7 +404,7 @@ class NewsScraper:
                         source=publisher,
                         published_at=published_at,
                     ),
-                }
+                )
             return None
 
         tasks = [process_item(item) for item in news_items[:5]]
@@ -347,7 +425,7 @@ class NewsScraper:
     )
     async def fetch_rss_tier(
         self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
-    ) -> list[str]:
+    ) -> list[dict[str, object]]:
         """Tier 2: RSS feeds (myFT / Google News fallback)."""
         results: list[str] = []
 
@@ -377,12 +455,15 @@ class NewsScraper:
                                 source="myFT",
                                 published_at=published_at,
                             ):
-                                return {
-                                    "title": title or "",
-                                    "source": "myFT",
-                                    "url": link,
-                                    "text": text,
-                                    "score": self._relevance_score(
+                                return self._to_article_record(
+                                    ticker=ticker,
+                                    title=title or "",
+                                    source="myFT",
+                                    url=link,
+                                    text=text,
+                                    published_at=published_at,
+                                    summary=self._summarize_text(text),
+                                    score=self._relevance_score(
                                         text,
                                         title,
                                         ticker,
@@ -390,7 +471,7 @@ class NewsScraper:
                                         source="myFT",
                                         published_at=published_at,
                                     ),
-                                }
+                                )
                             return None
                             
                         tasks = [process_entry(e) for e in feed.entries[:5]]
@@ -434,12 +515,15 @@ class NewsScraper:
                                 source="Google News",
                                 published_at=published_at,
                             ):
-                                return {
-                                    "title": title or "",
-                                    "source": "Google News",
-                                    "url": link,
-                                    "text": text,
-                                    "score": self._relevance_score(
+                                return self._to_article_record(
+                                    ticker=ticker,
+                                    title=title or "",
+                                    source="Google News",
+                                    url=link,
+                                    text=text,
+                                    published_at=published_at,
+                                    summary=self._summarize_text(text),
+                                    score=self._relevance_score(
                                         text,
                                         title,
                                         ticker,
@@ -447,7 +531,7 @@ class NewsScraper:
                                         source="Google News",
                                         published_at=published_at,
                                     ),
-                                }
+                                )
                             return None
                             
                         tasks = [process_entry(e) for e in feed.entries[:5]]
@@ -470,7 +554,7 @@ class NewsScraper:
     )
     async def fetch_finnhub_tier(
         self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
-    ) -> list[str]:
+    ) -> list[dict[str, object]]:
         """Tier 3: Finnhub."""
         if not self.finnhub_api_key:
             raise ValueError("FINNHUB_API_KEY not set")
@@ -497,6 +581,7 @@ class NewsScraper:
             async def process_item(item):
                 link = item.get("url")
                 title = item.get("headline", "")
+                source_summary = (item.get("summary") or "").strip()
                 text = await self.fetch_full_text(session, link)
                 word_count = len(text.split()) if text else 0
                 
@@ -514,12 +599,15 @@ class NewsScraper:
                     source="Finnhub API",
                     published_at=published_at,
                 ):
-                    return {
-                        "title": title or "",
-                        "source": "Finnhub API",
-                        "url": link,
-                        "text": text,
-                        "score": self._relevance_score(
+                    return self._to_article_record(
+                        ticker=ticker,
+                        title=title or "",
+                        source="Finnhub API",
+                        url=link,
+                        text=text,
+                        published_at=published_at,
+                        summary=source_summary or self._summarize_text(text),
+                        score=self._relevance_score(
                             text,
                             title,
                             ticker,
@@ -527,7 +615,7 @@ class NewsScraper:
                             source="Finnhub API",
                             published_at=published_at,
                         ),
-                    }
+                    )
                 return None
                 
             tasks = [process_item(item) for item in data[:20]]
@@ -542,14 +630,14 @@ class NewsScraper:
                 raise ValueError("No relevant text > 100 words extracted from Finnhub")
             return picked
 
-    async def scrape_all(
+    async def scrape_all_articles(
         self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
-    ) -> str:
+    ) -> list[dict[str, object]]:
         """Run the multi-tier scraper concurrently.
 
         Attempts all tiers simultaneously and collects one valid article from each source.
         """
-        final_articles: list[str] = []
+        final_articles: list[dict[str, object]] = []
 
         # Prioritize Finnhub first as requested.
         finnhub_result = await self.fetch_finnhub_tier(session, ticker, company_name)
@@ -567,15 +655,22 @@ class NewsScraper:
                 final_articles.extend(r)
 
         # Canonical URL dedupe across tiers.
-        unique_articles: list[str] = []
+        unique_articles: list[dict[str, object]] = []
         seen_urls: set[str] = set()
         for article in final_articles:
-            match = re.search(r"^URL:\s*(.*)$", article, flags=re.MULTILINE)
-            canonical = self._canonicalize_url(match.group(1).strip() if match else "")
+            if isinstance(article, str):
+                article = self._legacy_block_to_article(article, ticker)
+            canonical = self._canonicalize_url(str(article.get("url", "") or ""))
             if canonical and canonical in seen_urls:
                 continue
             if canonical:
                 seen_urls.add(canonical)
             unique_articles.append(article)
 
-        return "\n\n---\n\n".join(unique_articles)
+        return unique_articles
+
+    async def scrape_all(
+        self, session: aiohttp.ClientSession, ticker: str, company_name: str | None = None
+    ) -> str:
+        articles = await self.scrape_all_articles(session, ticker, company_name)
+        return self.serialize_articles(articles)

--- a/ai/pipeline/news_summarizer.py
+++ b/ai/pipeline/news_summarizer.py
@@ -23,6 +23,20 @@ class TrackSummaries(BaseModel):
     summaries: list[TickerSummary]
 
 
+class SummaryWithCitations(BaseModel):
+    summary: str = Field(
+        description=(
+            "A concise markdown-safe news brief. Use short bullets only when the news clearly breaks into distinct items."
+        )
+    )
+    citation_article_indices: list[int] = Field(
+        description=(
+            "Zero-based article indices backing the summary, ordered by importance. "
+            "Only include indices that exist in the provided article list."
+        )
+    )
+
+
 class NewsSummarizer:
     def __init__(
         self,
@@ -83,6 +97,62 @@ class NewsSummarizer:
 
         return chunks
 
+    def _clip_text(self, value: object, limit: int) -> str:
+        text = str(value or "").strip()
+        if len(text) <= limit:
+            return text
+        return text[: limit - 3].rstrip() + "..."
+
+    def summarize_articles_prompt(
+        self,
+        *,
+        subject: str,
+        articles: list[dict[str, object]],
+        sentence_budget: str,
+    ) -> str:
+        intro = (
+            f"You are writing a factual investor-facing news brief about {subject}. "
+            f"Write {sentence_budget}. Be specific about dates and numbers when the article text includes them. "
+            "Do not invent facts and do not give investment advice. "
+            "Return only JSON matching the schema. "
+            "Include the zero-based article indices that support the summary in citation_article_indices.\n\n"
+            "Articles:\n"
+        )
+        article_blocks = []
+        total_len = len(intro)
+        for idx, article in enumerate(articles):
+            block = "\n".join(
+                [
+                    f"Article {idx}:",
+                    f"Title: {self._clip_text(article.get('title', ''), 180)}",
+                    f"Publisher: {self._clip_text(article.get('publisher') or article.get('source') or '', 80)}",
+                    f"Published: {self._clip_text(article.get('published', ''), 40)}",
+                    f"URL: {self._clip_text(article.get('link') or article.get('url') or '', 220)}",
+                    f"Summary: {self._clip_text(article.get('summary', ''), 500)}",
+                    f"Text: {self._clip_text(article.get('text') or article.get('full_text') or '', 1200)}",
+                ]
+            )
+            projected = total_len + len(block) + 2
+            if article_blocks and projected > self.max_prompt_chars:
+                break
+            if not article_blocks and projected > self.max_prompt_chars:
+                block = "\n".join(
+                    [
+                        f"Article {idx}:",
+                        f"Title: {self._clip_text(article.get('title', ''), 120)}",
+                        f"Publisher: {self._clip_text(article.get('publisher') or article.get('source') or '', 60)}",
+                        f"Published: {self._clip_text(article.get('published', ''), 40)}",
+                        f"URL: {self._clip_text(article.get('link') or article.get('url') or '', 180)}",
+                        f"Summary: {self._clip_text(article.get('summary', ''), 300)}",
+                        f"Text: {self._clip_text(article.get('text') or article.get('full_text') or '', 500)}",
+                    ]
+                )
+            article_blocks.append(block)
+            total_len += len(block) + 2
+
+        context = "\n\n".join(article_blocks)
+        return intro + context
+
     async def _summarize_chunk(self, chunk: dict[str, str]) -> dict[str, str]:
         prompt = self._build_prompt(chunk)
         parsed_data = await self.client.create_structured(prompt, TrackSummaries)
@@ -131,6 +201,43 @@ class NewsSummarizer:
                     all_results[ticker] = "Error generating summary. Please check logs."
 
         return all_results
+
+    async def summarize_articles(
+        self,
+        *,
+        subject: str,
+        articles: list[dict[str, object]],
+        sentence_budget: str = "3-5 sentences",
+    ) -> SummaryWithCitations:
+        if not articles:
+            return SummaryWithCitations(summary="", citation_article_indices=[])
+
+        if not self.client:
+            count = min(3, len(articles))
+            return SummaryWithCitations(
+                summary="Mock summary sentence 1. Mock summary sentence 2.",
+                citation_article_indices=list(range(count)),
+            )
+
+        prompt = self.summarize_articles_prompt(
+            subject=subject,
+            articles=articles,
+            sentence_budget=sentence_budget,
+        )
+        parsed = await self.client.create_structured(prompt, SummaryWithCitations)
+        valid_indices = [
+            idx
+            for idx in parsed.citation_article_indices
+            if isinstance(idx, int) and 0 <= idx < len(articles)
+        ]
+        deduped_indices: list[int] = []
+        for idx in valid_indices:
+            if idx not in deduped_indices:
+                deduped_indices.append(idx)
+        return SummaryWithCitations(
+            summary=parsed.summary.strip(),
+            citation_article_indices=deduped_indices,
+        )
 
 
 if __name__ == "__main__":

--- a/ai/pipeline/ticker_news_service.py
+++ b/ai/pipeline/ticker_news_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from datetime import datetime, timezone
 from typing import Any
 
@@ -13,40 +12,69 @@ from ai.pipeline.news_scraper import NewsScraper
 from ai.pipeline.news_summarizer import NewsSummarizer
 
 
-def _extract_sources(scraped_text: str) -> list[dict[str, str]]:
-    """Extract structured source metadata from scraper output blocks."""
-    if not scraped_text or not scraped_text.strip():
-        return []
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
-    blocks = [b.strip() for b in re.split(r"\n\n---\n\n", scraped_text) if b.strip()]
-    sources: list[dict[str, str]] = []
-    seen: set[tuple[str, str]] = set()
 
-    for block in blocks:
-        title_match = re.search(r"^Title:\s*(.*)$", block, flags=re.MULTILINE)
-        source_match = re.search(r"^Source:\s*(.*)$", block, flags=re.MULTILINE)
-        url_match = re.search(r"^URL:\s*(.*)$", block, flags=re.MULTILINE)
+def _model_label(summarizer: NewsSummarizer) -> str | None:
+    return summarizer.model_config.model if summarizer else None
 
-        title = (title_match.group(1).strip() if title_match else "")
-        source = (source_match.group(1).strip() if source_match else "Unknown")
-        url = (url_match.group(1).strip() if url_match else "")
 
-        if not title and not url:
-            continue
-
-        key = (title, url)
-        if key in seen:
-            continue
-        seen.add(key)
-
-        payload = {
-            "title": title,
-            "source": source,
-            "url": url,
+def _build_news_items(
+    articles: list[dict[str, Any]],
+    *,
+    ticker_override: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    items = [
+        {
+            "title": article.get("title", ""),
+            "link": article.get("url", ""),
+            "publisher": article.get("source", "Unknown"),
+            "published": article.get("published"),
+            "summary": article.get("summary", ""),
+            "ticker": ticker_override or article.get("ticker", ""),
+            "text": article.get("text", ""),
         }
-        sources.append(payload)
+        for article in articles
+    ]
+    if limit is not None:
+        return items[:limit]
+    return items
 
-    return sources
+
+def _citations_from_indices(
+    articles: list[dict[str, Any]],
+    citation_indices: list[int],
+) -> list[dict[str, Any]]:
+    citations: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for idx in citation_indices:
+        if idx in seen or idx < 0 or idx >= len(articles):
+            continue
+        seen.add(idx)
+        article = articles[idx]
+        citations.append(
+            {
+                "ref": len(citations) + 1,
+                "article_index": idx,
+                "cited_text": article.get("title") or article.get("summary") or "",
+            }
+        )
+    return citations
+
+
+async def _scrape_ticker_articles(
+    scraper: NewsScraper,
+    session: aiohttp.ClientSession,
+    ticker: str,
+    company_name: str | None,
+) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        articles = await scraper.scrape_all_articles(session, ticker, company_name)
+        return articles, None
+    except Exception as e:
+        return [], str(e)
 
 
 async def get_ticker_news_summary(
@@ -57,8 +85,9 @@ async def get_ticker_news_summary(
     scraper: NewsScraper | None = None,
     summarizer: NewsSummarizer | None = None,
     session: aiohttp.ClientSession | None = None,
+    news_limit: int | None = None,
 ) -> dict[str, Any]:
-    """Return backend-friendly summary and sources for a single ticker."""
+    """Return backend/frontend-ready news and summary payload for a single ticker."""
     load_dotenv()
 
     normalized_ticker = (ticker or "").upper().strip()
@@ -81,46 +110,135 @@ async def get_ticker_news_summary(
         active_session = aiohttp.ClientSession(connector=connector)
 
     try:
-        scrape_error: str | None = None
+        articles, scrape_error = await _scrape_ticker_articles(
+            local_scraper,
+            active_session,
+            normalized_ticker,
+            company_name,
+        )
+        visible_news = _build_news_items(articles, ticker_override=normalized_ticker, limit=news_limit)
+
         summary_error: str | None = None
-
-        try:
-            raw_text = await local_scraper.scrape_all(active_session, normalized_ticker, company_name)
-        except Exception as e:
-            # Match ai-branch pipeline behavior: keep the flow alive even when a
-            # single ticker scrape fails.
-            raw_text = ""
-            scrape_error = str(e)
-
-        sources = _extract_sources(raw_text)
-
-        if not raw_text or not raw_text.strip():
-            summary_text = "No significant recent news."
-            status = "no_news"
+        if not articles:
+            summary_text = ""
+            citation_indices: list[int] = []
+            status = "scrape_error" if scrape_error else "no_news"
         else:
             try:
-                summaries = await local_summarizer.generate_batch_summaries({normalized_ticker: raw_text})
-                summary_text = summaries.get(normalized_ticker, "No significant recent news.")
+                summary_result = await local_summarizer.summarize_articles(
+                    subject=normalized_ticker,
+                    articles=visible_news,
+                    sentence_budget="3-5 sentences",
+                )
+                summary_text = summary_result.summary
+                citation_indices = summary_result.citation_article_indices
+                status = "ok"
             except Exception as e:
-                summary_text = "Error generating summary. Please check logs."
+                summary_text = ""
+                citation_indices = []
                 summary_error = str(e)
+                status = "summary_error"
 
-            status = "ok" if "Error generating summary" not in summary_text else "summary_error"
-
-        if scrape_error and status == "no_news":
-            status = "scrape_error"
-
+        citations = _citations_from_indices(visible_news, citation_indices)
         return {
             "ticker": normalized_ticker,
+            "news": visible_news,
             "summary": summary_text,
-            "sources": sources,
-            "source_count": len(sources),
-            "as_of": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "citations": citations,
+            "used_articles": len(visible_news),
+            "cached": False,
+            "model": _model_label(local_summarizer),
+            "as_of": _iso_now(),
             "status": status,
-            "summarizer_model": local_summarizer.model_config.name,
-            "scraped_text": raw_text,
             "errors": {
                 "scrape_error": scrape_error,
+                "summary_error": summary_error,
+            },
+        }
+    finally:
+        if owns_session and active_session is not None:
+            await active_session.close()
+
+
+async def get_track_news_payload(
+    constituents: list[dict[str, str]],
+    *,
+    track_name: str,
+    summarizer_model: str | None = None,
+    scraper: NewsScraper | None = None,
+    summarizer: NewsSummarizer | None = None,
+    session: aiohttp.ClientSession | None = None,
+    per_company: int = 3,
+) -> dict[str, Any]:
+    """Return frontend-ready aggregated news and summary payload for a track."""
+    load_dotenv()
+
+    local_scraper = scraper or NewsScraper()
+    if summarizer is None:
+        registry = load_registry()
+        model_to_use = summarizer_model or "claude-sonnet"
+        local_summarizer = NewsSummarizer(model_name=model_to_use, registry=registry)
+    else:
+        local_summarizer = summarizer
+
+    owns_session = session is None
+    active_session = session
+    if active_session is None:
+        connector = aiohttp.TCPConnector(limit=20)
+        active_session = aiohttp.ClientSession(connector=connector)
+
+    try:
+        aggregated_articles: list[dict[str, Any]] = []
+        scrape_errors: dict[str, str] = {}
+        for constituent in constituents:
+            ticker = (constituent.get("ticker") or "").upper().strip()
+            if not ticker:
+                continue
+            articles, scrape_error = await _scrape_ticker_articles(
+                local_scraper,
+                active_session,
+                ticker,
+                constituent.get("name"),
+            )
+            if scrape_error:
+                scrape_errors[ticker] = scrape_error
+            aggregated_articles.extend(articles[: max(0, per_company)])
+
+        news_items = _build_news_items(aggregated_articles)
+        summary_error: str | None = None
+        if not news_items:
+            summary_text = ""
+            citation_indices = []
+            status = "scrape_error" if scrape_errors else "no_news"
+        else:
+            try:
+                summary_result = await local_summarizer.summarize_articles(
+                    subject=f"the {track_name} investment track",
+                    articles=news_items,
+                    sentence_budget="3-5 sentences or a short bulleted list when useful",
+                )
+                summary_text = summary_result.summary
+                citation_indices = summary_result.citation_article_indices
+                status = "ok"
+            except Exception as e:
+                summary_text = ""
+                citation_indices = []
+                summary_error = str(e)
+                status = "summary_error"
+
+        return {
+            "news": news_items,
+            "summary": summary_text,
+            "citations": _citations_from_indices(news_items, citation_indices),
+            "used_articles": len(news_items),
+            "cached": False,
+            "model": _model_label(local_summarizer),
+            "as_of": _iso_now(),
+            "status": status,
+            "errors": {
+                "scrape_error": None if not scrape_errors else "; ".join(
+                    f"{ticker}: {err}" for ticker, err in sorted(scrape_errors.items())
+                ),
                 "summary_error": summary_error,
             },
         }
@@ -134,12 +252,30 @@ def get_ticker_news_summary_sync(
     *,
     company_name: str | None = None,
     summarizer_model: str | None = None,
+    news_limit: int | None = None,
 ) -> dict[str, Any]:
-    """Synchronous wrapper around get_ticker_news_summary."""
     return asyncio.run(
         get_ticker_news_summary(
             ticker,
             company_name=company_name,
             summarizer_model=summarizer_model,
+            news_limit=news_limit,
+        )
+    )
+
+
+def get_track_news_payload_sync(
+    constituents: list[dict[str, str]],
+    *,
+    track_name: str,
+    summarizer_model: str | None = None,
+    per_company: int = 3,
+) -> dict[str, Any]:
+    return asyncio.run(
+        get_track_news_payload(
+            constituents,
+            track_name=track_name,
+            summarizer_model=summarizer_model,
+            per_company=per_company,
         )
     )

--- a/ai/pipeline/ticker_news_service.py
+++ b/ai/pipeline/ticker_news_service.py
@@ -20,6 +20,19 @@ def _model_label(summarizer: NewsSummarizer) -> str | None:
     return summarizer.model_config.model if summarizer else None
 
 
+def _build_summarizer(
+    *,
+    summarizer: NewsSummarizer | None,
+    summarizer_model: str | None,
+) -> NewsSummarizer | None:
+    if summarizer is not None:
+        return summarizer
+    if summarizer_model is None:
+        summarizer_model = "claude-sonnet"
+    registry = load_registry()
+    return NewsSummarizer(model_name=summarizer_model, registry=registry)
+
+
 def _build_news_items(
     articles: list[dict[str, Any]],
     *,
@@ -99,12 +112,7 @@ async def get_ticker_news_summary(
 
     local_scraper = scraper or NewsScraper()
 
-    if summarizer is None:
-        registry = load_registry()
-        model_to_use = summarizer_model or "claude-sonnet"
-        local_summarizer = NewsSummarizer(model_name=model_to_use, registry=registry)
-    else:
-        local_summarizer = summarizer
+    local_summarizer: NewsSummarizer | None = summarizer
 
     owns_session = session is None
     active_session = session
@@ -142,6 +150,10 @@ async def get_ticker_news_summary(
             status = "ok"
         else:
             try:
+                local_summarizer = _build_summarizer(
+                    summarizer=local_summarizer,
+                    summarizer_model=summarizer_model,
+                )
                 summary_result = await local_summarizer.summarize_articles(
                     subject=normalized_ticker,
                     articles=summary_articles,
@@ -192,12 +204,7 @@ async def get_track_news_payload(
     load_dotenv()
 
     local_scraper = scraper or NewsScraper()
-    if summarizer is None:
-        registry = load_registry()
-        model_to_use = summarizer_model or "claude-sonnet"
-        local_summarizer = NewsSummarizer(model_name=model_to_use, registry=registry)
-    else:
-        local_summarizer = summarizer
+    local_summarizer: NewsSummarizer | None = summarizer
 
     owns_session = session is None
     active_session = session
@@ -235,6 +242,10 @@ async def get_track_news_payload(
             status = "ok"
         else:
             try:
+                local_summarizer = _build_summarizer(
+                    summarizer=local_summarizer,
+                    summarizer_model=summarizer_model,
+                )
                 summary_result = await local_summarizer.summarize_articles(
                     subject=f"the {track_name} investment track",
                     articles=summary_articles,

--- a/ai/pipeline/ticker_news_service.py
+++ b/ai/pipeline/ticker_news_service.py
@@ -25,19 +25,21 @@ def _build_news_items(
     *,
     ticker_override: str | None = None,
     limit: int | None = None,
+    include_text: bool = False,
 ) -> list[dict[str, Any]]:
-    items = [
-        {
+    items: list[dict[str, Any]] = []
+    for article in articles:
+        item = {
             "title": article.get("title", ""),
             "link": article.get("url", ""),
             "publisher": article.get("source", "Unknown"),
             "published": article.get("published"),
             "summary": article.get("summary", ""),
             "ticker": ticker_override or article.get("ticker", ""),
-            "text": article.get("text", ""),
         }
-        for article in articles
-    ]
+        if include_text:
+            item["text"] = article.get("text", "")
+        items.append(item)
     if limit is not None:
         return items[:limit]
     return items
@@ -86,6 +88,7 @@ async def get_ticker_news_summary(
     summarizer: NewsSummarizer | None = None,
     session: aiohttp.ClientSession | None = None,
     news_limit: int | None = None,
+    include_summary: bool = True,
 ) -> dict[str, Any]:
     """Return backend/frontend-ready news and summary payload for a single ticker."""
     load_dotenv()
@@ -116,18 +119,32 @@ async def get_ticker_news_summary(
             normalized_ticker,
             company_name,
         )
-        visible_news = _build_news_items(articles, ticker_override=normalized_ticker, limit=news_limit)
+        visible_news = _build_news_items(
+            articles,
+            ticker_override=normalized_ticker,
+            limit=news_limit,
+        )
+        summary_articles = _build_news_items(
+            articles,
+            ticker_override=normalized_ticker,
+            limit=news_limit,
+            include_text=True,
+        )
 
         summary_error: str | None = None
-        if not articles:
+        if not visible_news:
             summary_text = ""
             citation_indices: list[int] = []
             status = "scrape_error" if scrape_error else "no_news"
+        elif not include_summary:
+            summary_text = ""
+            citation_indices = []
+            status = "ok"
         else:
             try:
                 summary_result = await local_summarizer.summarize_articles(
                     subject=normalized_ticker,
-                    articles=visible_news,
+                    articles=summary_articles,
                     sentence_budget="3-5 sentences",
                 )
                 summary_text = summary_result.summary
@@ -147,7 +164,7 @@ async def get_ticker_news_summary(
             "citations": citations,
             "used_articles": len(visible_news),
             "cached": False,
-            "model": _model_label(local_summarizer),
+            "model": _model_label(local_summarizer) if include_summary else None,
             "as_of": _iso_now(),
             "status": status,
             "errors": {
@@ -169,6 +186,7 @@ async def get_track_news_payload(
     summarizer: NewsSummarizer | None = None,
     session: aiohttp.ClientSession | None = None,
     per_company: int = 3,
+    include_summary: bool = True,
 ) -> dict[str, Any]:
     """Return frontend-ready aggregated news and summary payload for a track."""
     load_dotenv()
@@ -205,16 +223,21 @@ async def get_track_news_payload(
             aggregated_articles.extend(articles[: max(0, per_company)])
 
         news_items = _build_news_items(aggregated_articles)
+        summary_articles = _build_news_items(aggregated_articles, include_text=True)
         summary_error: str | None = None
         if not news_items:
             summary_text = ""
             citation_indices = []
             status = "scrape_error" if scrape_errors else "no_news"
+        elif not include_summary:
+            summary_text = ""
+            citation_indices = []
+            status = "ok"
         else:
             try:
                 summary_result = await local_summarizer.summarize_articles(
                     subject=f"the {track_name} investment track",
-                    articles=news_items,
+                    articles=summary_articles,
                     sentence_budget="3-5 sentences or a short bulleted list when useful",
                 )
                 summary_text = summary_result.summary
@@ -232,7 +255,7 @@ async def get_track_news_payload(
             "citations": _citations_from_indices(news_items, citation_indices),
             "used_articles": len(news_items),
             "cached": False,
-            "model": _model_label(local_summarizer),
+            "model": _model_label(local_summarizer) if include_summary else None,
             "as_of": _iso_now(),
             "status": status,
             "errors": {
@@ -253,6 +276,7 @@ def get_ticker_news_summary_sync(
     company_name: str | None = None,
     summarizer_model: str | None = None,
     news_limit: int | None = None,
+    include_summary: bool = True,
 ) -> dict[str, Any]:
     return asyncio.run(
         get_ticker_news_summary(
@@ -260,6 +284,7 @@ def get_ticker_news_summary_sync(
             company_name=company_name,
             summarizer_model=summarizer_model,
             news_limit=news_limit,
+            include_summary=include_summary,
         )
     )
 
@@ -270,6 +295,7 @@ def get_track_news_payload_sync(
     track_name: str,
     summarizer_model: str | None = None,
     per_company: int = 3,
+    include_summary: bool = True,
 ) -> dict[str, Any]:
     return asyncio.run(
         get_track_news_payload(
@@ -277,5 +303,6 @@ def get_track_news_payload_sync(
             track_name=track_name,
             summarizer_model=summarizer_model,
             per_company=per_company,
+            include_summary=include_summary,
         )
     )

--- a/ai/tests/unit/test_ticker_news_service.py
+++ b/ai/tests/unit/test_ticker_news_service.py
@@ -84,6 +84,54 @@ class TestTickerNewsService:
             {"ref": 1, "article_index": 0, "cited_text": "Nvidia launches chip"},
             {"ref": 2, "article_index": 1, "cited_text": "Nvidia signs deal"},
         ]
+        assert "text" not in result["news"][0]
+
+    def test_news_only_path_skips_summarizer_and_respects_limit(self):
+        scraper = StubScraper(
+            {
+                "NVDA": [
+                    _article(ticker="NVDA", title="One", url="https://example.com/1"),
+                    _article(ticker="NVDA", title="Two", url="https://example.com/2"),
+                ]
+            }
+        )
+        summarizer = StubSummarizer()
+        summarizer.summarize_articles = AsyncMock(side_effect=AssertionError("should not be called"))
+
+        result = asyncio.run(
+            get_ticker_news_summary(
+                "NVDA",
+                scraper=scraper,
+                summarizer=summarizer,
+                news_limit=1,
+                include_summary=False,
+            )
+        )
+
+        assert result["status"] == "ok"
+        assert result["summary"] == ""
+        assert result["used_articles"] == 1
+        assert result["news"][0]["title"] == "One"
+        assert result["model"] is None
+
+    def test_zero_visible_news_does_not_report_ok(self):
+        scraper = StubScraper(
+            {"NVDA": [_article(ticker="NVDA", title="One", url="https://example.com/1")]}
+        )
+        summarizer = StubSummarizer()
+
+        result = asyncio.run(
+            get_ticker_news_summary(
+                "NVDA",
+                scraper=scraper,
+                summarizer=summarizer,
+                news_limit=0,
+            )
+        )
+
+        assert result["status"] == "no_news"
+        assert result["summary"] == ""
+        assert result["used_articles"] == 0
 
     def test_no_news_payload_stays_shape_stable(self):
         scraper = StubScraper({"NVDA": []})

--- a/ai/tests/unit/test_ticker_news_service.py
+++ b/ai/tests/unit/test_ticker_news_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from ai.pipeline.news_summarizer import SummaryWithCitations
 from ai.pipeline.ticker_news_service import (

--- a/ai/tests/unit/test_ticker_news_service.py
+++ b/ai/tests/unit/test_ticker_news_service.py
@@ -1,0 +1,139 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from ai.pipeline.news_summarizer import SummaryWithCitations
+from ai.pipeline.ticker_news_service import (
+    get_ticker_news_summary,
+    get_track_news_payload,
+)
+
+
+def _article(
+    *,
+    ticker: str,
+    title: str,
+    url: str,
+    source: str = "Reuters",
+    published: str = "2026-04-20T00:00:00Z",
+    summary: str = "Short source summary.",
+    text: str = "Full article text " + ("word " * 120),
+    score: float = 1.0,
+):
+    return {
+        "ticker": ticker,
+        "title": title,
+        "source": source,
+        "url": url,
+        "published": published,
+        "summary": summary,
+        "text": text,
+        "score": score,
+    }
+
+
+class StubScraper:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    async def scrape_all_articles(self, session, ticker, company_name=None):
+        return list(self.mapping.get(ticker, []))
+
+
+class StubSummarizer:
+    def __init__(self, model="claude-sonnet-4-20250514", response=None):
+        self.model_config = type("Config", (), {"model": model, "name": "claude-sonnet"})
+        self._response = response or SummaryWithCitations(
+            summary="A concise summary.",
+            citation_article_indices=[1, 0],
+        )
+
+    async def summarize_articles(self, **kwargs):
+        return self._response
+
+
+class TestTickerNewsService:
+    def test_ticker_payload_matches_frontend_contract(self):
+        scraper = StubScraper(
+            {
+                "NVDA": [
+                    _article(ticker="NVDA", title="Nvidia launches chip", url="https://example.com/1"),
+                    _article(ticker="NVDA", title="Nvidia signs deal", url="https://example.com/2"),
+                ]
+            }
+        )
+        summarizer = StubSummarizer(
+            response=SummaryWithCitations(
+                summary="Nvidia launched a new chip and signed a supply deal.",
+                citation_article_indices=[0, 1],
+            )
+        )
+
+        result = asyncio.run(
+            get_ticker_news_summary("NVDA", scraper=scraper, summarizer=summarizer)
+        )
+
+        assert result["ticker"] == "NVDA"
+        assert result["model"] == "claude-sonnet-4-20250514"
+        assert result["used_articles"] == 2
+        assert result["status"] == "ok"
+        assert len(result["news"]) == 2
+        assert result["news"][0]["publisher"] == "Reuters"
+        assert result["news"][0]["published"] == "2026-04-20T00:00:00Z"
+        assert result["news"][0]["summary"] == "Short source summary."
+        assert result["citations"] == [
+            {"ref": 1, "article_index": 0, "cited_text": "Nvidia launches chip"},
+            {"ref": 2, "article_index": 1, "cited_text": "Nvidia signs deal"},
+        ]
+
+    def test_no_news_payload_stays_shape_stable(self):
+        scraper = StubScraper({"NVDA": []})
+        summarizer = StubSummarizer()
+
+        result = asyncio.run(
+            get_ticker_news_summary("NVDA", scraper=scraper, summarizer=summarizer)
+        )
+
+        assert result["news"] == []
+        assert result["summary"] == ""
+        assert result["citations"] == []
+        assert result["used_articles"] == 0
+        assert result["status"] == "no_news"
+
+    def test_track_payload_aggregates_articles_and_citations(self):
+        scraper = StubScraper(
+            {
+                "AAPL": [
+                    _article(ticker="AAPL", title="Apple unveils hardware", url="https://example.com/apple"),
+                    _article(ticker="AAPL", title="Apple supplier update", url="https://example.com/apple2"),
+                ],
+                "MSFT": [
+                    _article(ticker="MSFT", title="Microsoft closes AI deal", url="https://example.com/msft"),
+                ],
+            }
+        )
+        summarizer = StubSummarizer(
+            response=SummaryWithCitations(
+                summary="- **AAPL** launch.\n- **MSFT** acquisition.",
+                citation_article_indices=[2, 0],
+            )
+        )
+
+        result = asyncio.run(
+            get_track_news_payload(
+                [
+                    {"ticker": "AAPL", "name": "Apple"},
+                    {"ticker": "MSFT", "name": "Microsoft"},
+                ],
+                track_name="Big Tech",
+                scraper=scraper,
+                summarizer=summarizer,
+                per_company=2,
+            )
+        )
+
+        assert result["used_articles"] == 3
+        assert [item["ticker"] for item in result["news"]] == ["AAPL", "AAPL", "MSFT"]
+        assert result["citations"] == [
+            {"ref": 1, "article_index": 2, "cited_text": "Microsoft closes AI deal"},
+            {"ref": 2, "article_index": 0, "cited_text": "Apple unveils hardware"},
+        ]

--- a/backend/db/seed.py
+++ b/backend/db/seed.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TRACKS_CANDIDATES = [
-    REPO_ROOT / "ticker_track.json",
+    REPO_ROOT / "ticker_track_cleaned.json",
     REPO_ROOT / "investment_tracks.json",
     REPO_ROOT / "frontend" / "investment_tracks.json",
 ]

--- a/backend/db/seed_prod.py
+++ b/backend/db/seed_prod.py
@@ -41,7 +41,7 @@ try:
 except ModuleNotFoundError:
     from seed_supplier_subsidary import seed_relationships
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scraper"))
 from scraper import StockScraper  # noqa: E402
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -490,10 +490,7 @@ def get_company_summary(ticker):
         news_limit=8,
         include_summary=True,
     )
-    result = {
-        **service_payload,
-        "news": None,
-    }
+    result = dict(service_payload)
     if _should_cache_summary_payload(result):
         _cache_set(cache_key, result)
     return jsonify(result)
@@ -530,7 +527,7 @@ def get_track_summary(slug):
         per_company=3,
         include_summary=True,
     )
-    result = {**service_payload, "news": None}
+    result = dict(service_payload)
     if _should_cache_summary_payload(result):
         _cache_set(cache_key, result)
     return jsonify(result)

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,10 +4,26 @@ import base64
 import hashlib
 import json
 import os
+from pathlib import Path
+import sys
 import time
 import psycopg2
 import psycopg2.extras
 from config import DATABASE_URL
+
+try:
+    from ai.pipeline.ticker_news_service import (
+        get_ticker_news_summary_sync,
+        get_track_news_payload_sync,
+    )
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from ai.pipeline.ticker_news_service import (
+        get_ticker_news_summary_sync,
+        get_track_news_payload_sync,
+    )
 
 app = Flask(__name__)
 
@@ -50,25 +66,9 @@ def _is_admin() -> bool:
     email = (user.get("email") or "").lower()
     return bool(email) and email in ADMIN_EMAILS
 
-
-# ── Anthropic client (optional; for /summary endpoints) ──────────────────
-ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
-_anthropic = None
-if ANTHROPIC_API_KEY:
-    try:
-        import anthropic
-        _anthropic = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
-        print("[nexus] anthropic client initialized (Claude Haiku 4.5)")
-    except Exception as e:
-        print(f"[nexus] anthropic init failed: {e} — /summary will return empty")
-else:
-    print("[nexus] ANTHROPIC_API_KEY unset — /summary will return empty")
-
-
-# ── In-memory TTL cache for /summary responses ───────────────────────────
+# ── In-memory TTL cache for AI-backed news + summaries ───────────────────
 # Simple dict-of-(timestamp, payload). Process-local so multiple gunicorn
-# workers don't share — that's fine at this scale (~dozens of calls/day),
-# worst case we do a handful of extra Anthropic calls.
+# workers don't share — that's fine at this scale (~dozens of calls/day).
 _summary_cache: dict[str, tuple[float, dict]] = {}
 SUMMARY_CACHE_TTL = 15 * 60  # 15 minutes
 
@@ -82,6 +82,11 @@ def _cache_get(key: str):
 
 def _cache_set(key: str, value: dict):
     _summary_cache[key] = (time.time(), value)
+
+
+def _should_cache_summary_payload(payload: dict) -> bool:
+    status = payload.get("status")
+    return status in (None, "ok", "no_news")
 
 
 # ── Firebase auth (optional; off in dev, on in prod) ─────────────────────
@@ -178,6 +183,54 @@ def track_color(track_name: str) -> str:
 
 def slugify(name: str) -> str:
     return "".join(c.lower() if c.isalnum() else "-" for c in name).strip("-")
+
+
+def _lookup_company_name(ticker: str) -> str | None:
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM companies WHERE ticker = %s", (ticker,))
+    row = cursor.fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _get_ticker_pipeline_payload(
+    ticker: str,
+    *,
+    company_name: str | None = None,
+) -> dict:
+    normalized_ticker = ticker.upper().strip()
+    cache_key = f"ticker-pipeline:{normalized_ticker}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    payload = get_ticker_news_summary_sync(
+        normalized_ticker,
+        company_name=company_name,
+    )
+    _cache_set(cache_key, payload)
+    return payload
+
+
+def _get_track_pipeline_payload(
+    *,
+    track_name: str,
+    constituents: list[dict[str, str]],
+    per_company: int = 3,
+) -> dict:
+    cache_key = f"track-pipeline:{slugify(track_name)}:{per_company}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    payload = get_track_news_payload_sync(
+        constituents,
+        track_name=track_name,
+        per_company=per_company,
+    )
+    _cache_set(cache_key, payload)
+    return payload
 
 
 @api.route("/companies")
@@ -362,59 +415,20 @@ def get_track_companies(track_id):
     conn.close()
     return jsonify(companies)
 
-
-def fetch_news_for(ticker: str, limit: int = 8) -> list:
-    """Pull news headlines for a ticker via yfinance (Yahoo Finance, free)."""
-    try:
-        import yfinance as yf
-    except Exception:
-        return []
-    try:
-        items = yf.Ticker(ticker).news or []
-    except Exception as e:
-        print(f"[news] yfinance failed for {ticker}: {e}")
-        return []
-
-    out = []
-    for it in items[:limit]:
-        # yfinance returns either flat dicts or wrapped {content: {...}} shapes
-        # depending on version — flatten both.
-        c = it.get("content") or it
-        title = c.get("title") or it.get("title")
-        if not title:
-            continue
-        link = (
-            (c.get("clickThroughUrl") or {}).get("url")
-            or (c.get("canonicalUrl") or {}).get("url")
-            or it.get("link")
-        )
-        publisher = (
-            (c.get("provider") or {}).get("displayName")
-            or c.get("publisher")
-            or it.get("publisher")
-        )
-        published = c.get("pubDate") or it.get("providerPublishTime")
-        summary = c.get("summary") or c.get("description") or ""
-        out.append({
-            "title": title,
-            "link": link,
-            "publisher": publisher,
-            "published": published,
-            "summary": summary,
-            "ticker": ticker,
-        })
-    return out
-
-
 @api.route("/companies/<ticker>/news")
 def get_company_news(ticker):
     limit = request.args.get("limit", default=8, type=int)
-    return jsonify(fetch_news_for(ticker.upper(), limit=limit))
+    ticker = ticker.upper().strip()
+    service_payload = _get_ticker_pipeline_payload(
+        ticker,
+        company_name=_lookup_company_name(ticker),
+    )
+    return jsonify((service_payload.get("news") or [])[:limit])
 
 
 @api.route("/tracks/<slug>/news")
 def get_track_news(slug):
-    """Aggregate news for the top-N companies (by market cap) in this track."""
+    """Aggregate pipeline-scraped news for the top-N companies in this track."""
     conn = get_conn()
     cursor = conn.cursor()
     cursor.execute("SELECT id, name FROM investment_tracks")
@@ -432,179 +446,22 @@ def get_track_news(slug):
     per_company = request.args.get("per", default=3, type=int)
 
     cursor.execute("""
-        SELECT c.ticker
+        SELECT c.ticker, c.name
         FROM companies c
         JOIN company_tracks ct ON ct.company_id = c.id
         WHERE ct.track_id = %s
         ORDER BY COALESCE(c.market_cap, 0) DESC
         LIMIT %s
     """, (track_id, top_n))
-    tickers = [r[0] for r in cursor.fetchall()]
+    companies = [{"ticker": r[0], "name": r[1]} for r in cursor.fetchall()]
     conn.close()
 
-    aggregated = []
-    for t in tickers:
-        aggregated.extend(fetch_news_for(t, limit=per_company))
-    return jsonify(aggregated)
-
-
-# ── AI-summary endpoints (Claude Haiku 4.5 + native citations) ───────────
-#
-# The citations API returns structured references into the `documents`
-# array we pass in — we give one document per news article, which lets
-# the frontend scroll the exact article into view when the user clicks
-# a [1] [2] [3] marker in the summary.
-#
-# Design notes:
-#   - POST, not GET, so browser link-prefetch / prerender doesn't trigger
-#     an API call (and an Anthropic bill)
-#   - 15-min in-memory cache on the server. First user per ticker pays
-#     the API call; the next ~dozens within 15 min are free
-#   - Empty payload (not error) when ANTHROPIC_API_KEY isn't set, so the
-#     frontend degrades gracefully in dev
-#   - Usage logged per call so `journalctl -u nexus -f | grep summary`
-#     shows live cost
-
-def build_summary(
-    articles: list[dict],
-    subject: str,
-    constituents: list[dict] | None = None,
-) -> dict:
-    """
-    Turn a list of news articles into a Claude-generated summary with
-    inline citations.
-
-    Args:
-        articles: each has {title, summary, link, publisher, published, ticker}.
-        subject: ticker ('NVDA') or track descriptor
-            ('the Advertising Agencies - China investment track').
-        constituents: for track summaries, the list of companies whose news
-            is aggregated in `articles`. Shape: [{ticker, name}, ...]. Without
-            this the model has no way to connect a track label to the news
-            documents and often refuses with 'I don't have information about X'.
-
-    Returns:
-        {
-          "summary": "...", "citations": [...], "used_articles": N,
-          "cached": False, "model": "..."
-        }
-    """
-    if not _anthropic or not articles:
-        return {"summary": "", "citations": [], "used_articles": 0,
-                "cached": False, "model": None}
-
-    documents = []
-    for i, art in enumerate(articles):
-        body_parts = []
-        if art.get("title"):     body_parts.append(art["title"])
-        if art.get("summary"):   body_parts.append(art["summary"])
-        body = "\n\n".join(body_parts).strip()
-        if not body:
-            continue
-        documents.append({
-            "type": "document",
-            "source": {
-                "type": "content",
-                "content": [{"type": "text", "text": body}],
-            },
-            "title": art.get("publisher") or f"Article {i + 1}",
-            "context": f"article_index={i}; ticker={art.get('ticker', '')}",
-            "citations": {"enabled": True},
-        })
-
-    if not documents:
-        return {"summary": "", "citations": [], "used_articles": 0,
-                "cached": False, "model": None}
-
-    # Build the user-message prompt. For track summaries we inject the
-    # constituent companies explicitly so the model knows the documents
-    # ARE the track's evidence and doesn't refuse with "I don't have info
-    # about <track name>."
-    user_prompt_lines = []
-    if constituents:
-        roster = ", ".join(
-            f"{c['ticker']} ({c['name']})" if c.get("name") else c["ticker"]
-            for c in constituents
-        )
-        user_prompt_lines.append(
-            f"The following news articles cover {subject}, which includes these "
-            f"public companies: {roster}. Treat each article as news about one "
-            f"of these companies."
-        )
-    user_prompt_lines.append(
-        f"Summarize the recent news about {subject} in 3-5 sentences with "
-        "inline citations. If multiple companies have distinct news items, "
-        "a short bulleted list is appropriate."
+    service_payload = _get_track_pipeline_payload(
+        track_name=target[1],
+        constituents=companies,
+        per_company=per_company,
     )
-    user_prompt = "\n\n".join(user_prompt_lines)
-
-    msg = _anthropic.messages.create(
-        model="claude-haiku-4-5-20251001",
-        max_tokens=700,
-        system=(
-            f"You are writing a 3-5 sentence news brief about {subject} for a "
-            "retail investor. Cite every factual claim back to the source "
-            "documents using the citations API. Be specific about dates and "
-            "numbers when the source has them. Do not invent facts. Neutral, "
-            "factual tone — no hype, no recommendations.\n\n"
-            "Format with light markdown where it aids readability: "
-            "**bold** for the 1-2 most important phrases per summary, "
-            "and a short bulleted list if the news naturally breaks into "
-            "multiple distinct items. Do NOT use headings, tables, or code "
-            "blocks. Plain prose is fine when nothing stands out."
-        ),
-        messages=[{
-            "role": "user",
-            "content": [
-                *documents,
-                {"type": "text", "text": user_prompt},
-            ],
-        }],
-    )
-
-    # Walk content blocks. Each text block can have a `citations` list.
-    # The SDK may expose fields as attrs (v0.x) or dict keys (rare) — handle
-    # both without blowing up.
-    def _get(obj, name, default=None):
-        if hasattr(obj, name):
-            return getattr(obj, name, default)
-        if isinstance(obj, dict):
-            return obj.get(name, default)
-        return default
-
-    text_parts = []
-    cite_list = []
-    ref_counter = 0
-    for block in msg.content:
-        if _get(block, "type") != "text":
-            continue
-        text_parts.append(_get(block, "text", ""))
-        for c in (_get(block, "citations") or []):
-            ref_counter += 1
-            cite_list.append({
-                "ref": ref_counter,
-                "article_index": _get(c, "document_index"),
-                "cited_text": _get(c, "cited_text"),
-            })
-
-    # Log usage (journalctl -u nexus -f | grep summary)
-    try:
-        usage = msg.usage
-        in_tok = getattr(usage, "input_tokens", 0)
-        out_tok = getattr(usage, "output_tokens", 0)
-        cost_usd = (in_tok * 1 + out_tok * 5) / 1_000_000  # Haiku 4.5 pricing
-        print(f"[summary] subject={subject!r} docs={len(documents)} "
-              f"input={in_tok} output={out_tok} cost=${cost_usd:.4f}")
-    except Exception:
-        pass
-
-    return {
-        "summary": "".join(text_parts).strip(),
-        "citations": cite_list,
-        "used_articles": len(documents),
-        "cached": False,
-        "model": "claude-haiku-4-5-20251001",
-    }
+    return jsonify(service_payload.get("news") or [])
 
 
 @api.route("/companies/<ticker>/summary", methods=["POST"])
@@ -614,9 +471,16 @@ def get_company_summary(ticker):
     cached = _cache_get(cache_key)
     if cached:
         return jsonify({**cached, "cached": True})
-    articles = fetch_news_for(ticker, limit=10)
-    result = build_summary(articles, subject=ticker)
-    _cache_set(cache_key, result)
+    service_payload = _get_ticker_pipeline_payload(
+        ticker,
+        company_name=_lookup_company_name(ticker),
+    )
+    result = {
+        **service_payload,
+        "news": None,
+    }
+    if _should_cache_summary_payload(result):
+        _cache_set(cache_key, result)
     return jsonify(result)
 
 
@@ -645,16 +509,14 @@ def get_track_summary(slug):
     constituents = [{"ticker": r[0], "name": r[1]} for r in cursor.fetchall()]
     conn.close()
 
-    articles = []
-    for c in constituents:
-        articles.extend(fetch_news_for(c["ticker"], limit=3))
-
-    result = build_summary(
-        articles,
-        subject=f"the {track_name} investment track",
+    service_payload = _get_track_pipeline_payload(
+        track_name=track_name,
         constituents=constituents,
+        per_company=3,
     )
-    _cache_set(cache_key, result)
+    result = {**service_payload, "news": None}
+    if _should_cache_summary_payload(result):
+        _cache_set(cache_key, result)
     return jsonify(result)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -198,9 +198,12 @@ def _get_ticker_pipeline_payload(
     ticker: str,
     *,
     company_name: str | None = None,
+    news_limit: int | None = None,
+    include_summary: bool = True,
 ) -> dict:
     normalized_ticker = ticker.upper().strip()
-    cache_key = f"ticker-pipeline:{normalized_ticker}"
+    mode = "summary" if include_summary else "news"
+    cache_key = f"ticker-pipeline:{normalized_ticker}:{mode}:{news_limit}"
     cached = _cache_get(cache_key)
     if cached:
         return cached
@@ -208,8 +211,11 @@ def _get_ticker_pipeline_payload(
     payload = get_ticker_news_summary_sync(
         normalized_ticker,
         company_name=company_name,
+        news_limit=news_limit,
+        include_summary=include_summary,
     )
-    _cache_set(cache_key, payload)
+    if _should_cache_summary_payload(payload):
+        _cache_set(cache_key, payload)
     return payload
 
 
@@ -218,8 +224,10 @@ def _get_track_pipeline_payload(
     track_name: str,
     constituents: list[dict[str, str]],
     per_company: int = 3,
+    include_summary: bool = True,
 ) -> dict:
-    cache_key = f"track-pipeline:{slugify(track_name)}:{per_company}"
+    mode = "summary" if include_summary else "news"
+    cache_key = f"track-pipeline:{slugify(track_name)}:{mode}:{per_company}"
     cached = _cache_get(cache_key)
     if cached:
         return cached
@@ -228,8 +236,10 @@ def _get_track_pipeline_payload(
         constituents,
         track_name=track_name,
         per_company=per_company,
+        include_summary=include_summary,
     )
-    _cache_set(cache_key, payload)
+    if _should_cache_summary_payload(payload):
+        _cache_set(cache_key, payload)
     return payload
 
 
@@ -422,8 +432,10 @@ def get_company_news(ticker):
     service_payload = _get_ticker_pipeline_payload(
         ticker,
         company_name=_lookup_company_name(ticker),
+        news_limit=limit,
+        include_summary=False,
     )
-    return jsonify((service_payload.get("news") or [])[:limit])
+    return jsonify(service_payload.get("news") or [])
 
 
 @api.route("/tracks/<slug>/news")
@@ -460,6 +472,7 @@ def get_track_news(slug):
         track_name=target[1],
         constituents=companies,
         per_company=per_company,
+        include_summary=False,
     )
     return jsonify(service_payload.get("news") or [])
 
@@ -474,6 +487,8 @@ def get_company_summary(ticker):
     service_payload = _get_ticker_pipeline_payload(
         ticker,
         company_name=_lookup_company_name(ticker),
+        news_limit=8,
+        include_summary=True,
     )
     result = {
         **service_payload,
@@ -513,6 +528,7 @@ def get_track_summary(slug):
         track_name=track_name,
         constituents=constituents,
         per_company=3,
+        include_summary=True,
     )
     result = {**service_payload, "news": None}
     if _should_cache_summary_payload(result):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,10 @@ curl_cffi
 python-dotenv
 beautifulsoup4
 firebase-admin
-anthropic
+aiohttp
+pydantic
+pyyaml
+openai
+trafilatura
+feedparser
+tenacity

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -34,8 +34,10 @@ from curl_cffi.requests import AsyncSession
 # file still references it in the __main__ SEC-dump path. Keep the import
 # optional so `from scraper import StockScraper` works for the hot path
 # (Yahoo Finance pulls) even when ten_k_fetch.py isn't in sys.path.
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "sec_pipeline" / "suppliers"))
 try:
-    from ten_k_fetch import fetch_sec_sections
+    from fetcher import fetch_sec_sections
 except ModuleNotFoundError:
     def fetch_sec_sections(ticker):  # type: ignore
         raise RuntimeError(

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -34,7 +34,7 @@ from curl_cffi.requests import AsyncSession
 # file still references it in the __main__ SEC-dump path. Keep the import
 # optional so `from scraper import StockScraper` works for the hot path
 # (Yahoo Finance pulls) even when ten_k_fetch.py isn't in sys.path.
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent
 SEC_SUPPLIERS_DIR = ROOT / "sec_pipeline" / "suppliers"
 SEC_SUPPLIERS_DIR_STR = str(SEC_SUPPLIERS_DIR)
 if SEC_SUPPLIERS_DIR.is_dir() and SEC_SUPPLIERS_DIR_STR not in sys.path:

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -35,7 +35,10 @@ from curl_cffi.requests import AsyncSession
 # optional so `from scraper import StockScraper` works for the hot path
 # (Yahoo Finance pulls) even when ten_k_fetch.py isn't in sys.path.
 ROOT = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(ROOT / "sec_pipeline" / "suppliers"))
+SEC_SUPPLIERS_DIR = ROOT / "sec_pipeline" / "suppliers"
+SEC_SUPPLIERS_DIR_STR = str(SEC_SUPPLIERS_DIR)
+if SEC_SUPPLIERS_DIR.is_dir() and SEC_SUPPLIERS_DIR_STR not in sys.path:
+    sys.path.insert(0, SEC_SUPPLIERS_DIR_STR)
 try:
     from fetcher import fetch_sec_sections
 except ModuleNotFoundError:


### PR DESCRIPTION
closes issue #23 

## Summary
  Before this change, the backend bypassed the AI pipeline and maintained duplicate logic
  for:
  - news fetching
  - summary generation
  - response formatting

  Routed the backend news and summary endpoints through the AI pipeline instead of the old
  baked-in Yahoo Finance + direct Claude path in `backend/main.py`.

 moved the response-shaping logic into `ai/pipeline/`, so the backend is now mostly
  responsible for DB lookup, route handling, and caching.

  ## Changes

  - Added structured article handling in the AI scraper pipeline
    - Preserve article metadata needed by the frontend: title, publisher, link, published
  timestamp, ticker, and a short summary/excerpt
    - Keep canonical URL dedupe while preserving the original article URL in the payload

  - Extended the AI summarizer to support frontend-ready article summaries
    - Added structured summary generation with citation article indices
    - Added prompt clipping for aggregated track summaries so track-level requests do not
  blow past prompt limits

  - Reworked `ticker_news_service.py`
    - `get_ticker_news_summary(...)` now returns frontend-ready `news`, `summary`,
  `citations`, `used_articles`, `model`, `status`, and `errors`
    - Added track-level aggregation support so `/tracks/<slug>/summary` is generated from
  one aggregated evidence set instead of stitched per-ticker summaries

  - Simplified backend routes
    - `/companies/<ticker>/news`
    - `/companies/<ticker>/summary`
    - `/tracks/<slug>/news`
    - `/tracks/<slug>/summary`
    now pass through AI pipeline payloads instead of rebuilding the contract in the
  backend

  - Pulled in the relevant upstream seed fixes for investment tracks
    - use `ticker_track_cleaned.json`
    - fix `seed_prod.py` repo-root resolution
    - fix the scraper SEC import path used by the seeder

  - Added targeted unit coverage for the new ticker/track payload contract


  ## Testing

  Ran:

- ai/tests/unit/test_news_service.py

  - 10 passed

  Also manually verified locally:

  - /nexus/api/companies/NVDA/news
  - /nexus/api/companies/NVDA/summary
  - /nexus/api/tracks
  - /nexus/api/tracks/<slug>/summary

  ## Notes

  - Some tracks may still have sparse or inconsistent news coverage depending on what the
    scraper can find for their constituent tickers.
  - Failed summary results are no longer cached, so track-summary failures recover on retry instead of being stuck for the cache TTL.